### PR TITLE
Add rough NGC CLI wrapper

### DIFF
--- a/src/triton_cli/main.py
+++ b/src/triton_cli/main.py
@@ -15,5 +15,6 @@ def main():
     except Exception as e:
         logger.error(f"{e}")
 
+
 if __name__ == "__main__":
     main()

--- a/src/triton_cli/repository.py
+++ b/src/triton_cli/repository.py
@@ -28,6 +28,7 @@ team = {team}
 SOURCE_PREFIX_HUGGINGFACE = "hf:"
 SOURCE_PREFIX_NGC = "ngc:"
 
+
 # NOTE: Thin wrapper around NGC CLI is a WAR for now.
 # TODO: Move out to generic files/interface for remote model stores
 class NGCWrapper:
@@ -40,7 +41,7 @@ class NGCWrapper:
             team="playground",
             api_key=api_key,
             # For interactive output to see download progress
-            format_type="ascii"
+            format_type="ascii",
         )
 
     # To avoid having to interact with NGC CLI interactively,
@@ -53,10 +54,7 @@ class NGCWrapper:
 
         logger.info("Generating NGC config")
         config = NGC_CONFIG_TEMPLATE.format(
-            api_key=api_key,
-            format_type=format_type,
-            org=org,
-            team=team
+            api_key=api_key, format_type=format_type, org=org, team=team
         )
         config_file.write_text(config)
 
@@ -73,6 +71,7 @@ class NGCWrapper:
         if output.returncode:
             err = output.stderr.decode("utf-8")
             raise Exception(f"Failed to download {model} from NGC:\n{err}")
+
 
 # Can eventually be an interface and have implementations
 # for remote stores or similar, but keeping it simple for now.


### PR DESCRIPTION
Add ability to download model from NGC by thinly wrapping CLI.

This assumes `ngc` CLI is available in the container/environment, and requires that you set the following environment variable to authenticate pulling from private registries:
```
export NGC_API _KEY=<my_token_here>
```

Will follow up with any cleanup/changes required when work with @oandreeva-nv and @jbkyang-nvi is closer on setting up TRT LLM repo details .