### PR TITLE
Add profile subcommand to run perf analyzer

### DIFF
--- a/src/triton_cli/parser.py
+++ b/src/triton_cli/parser.py
@@ -92,8 +92,8 @@ def handle_model(args: argparse.Namespace):
         print("profile()")
         Profiler.profile(
             model=args.model,
-            batch_size=64,
-            url="localhost:8001",
+            batch_size=1,
+            url=f"{args.url}:{args.port}",
             input_length=2048,
         )
     elif args.subcommand == "config":

--- a/src/triton_cli/profiler.py
+++ b/src/triton_cli/profiler.py
@@ -421,6 +421,13 @@ def profile(args, export_file):
         f"--input-data={INPUT_FILENAME} "
         f"--profile-export-file={export_file} "
     )
+    if args.backend == "trtllm":
+        command += (
+            "--shape=text_input:1 "
+            "--shape=max_tokens:1 "
+            "--shape=bad_words:1 "
+            "--shape=stop_words:1 "
+        )
     if args.periodic_concurrency_range:
         start, end, step = args.periodic_concurrency_range
         command += (
@@ -450,13 +457,13 @@ def prepare_export_file(args, prompt):
 
 def prepare_input_data(input_data, prompt):
     """Insert the prompt to send into input JSON data."""
-    input_data["data"][0]["prompt"] = [prompt]
+    input_data["data"][0]["text_input"] = [prompt]
     save_json_data(input_data, INPUT_FILENAME)
 
 
 def generate_prompts(args, input_data):
     """Generate dummy prompts if not specified by input JSON file."""
-    prompt = input_data["data"][0]["prompt"][0]
+    prompt = input_data["data"][0]["text_input"][0]
 
     if not prompt:  # Generate dummy prompt
         assert args.prompt_size_range, "Must specify --prompt-size-range."
@@ -536,16 +543,20 @@ def construct_trtllm_input_data(args):
         input_data = {
             "data": [
                 {
-                    "prompt": [""],
+                    "text_input": [""],
                     "max_tokens": [128],
-                    "temperature": [0.2],
-                    "top_p": [0.7],
+                    "stream": [True],
+                    "bad_words": [""],
+                    "stop_words": [""],
                 }
             ]
         }
 
     # If command line option is specified, overwrite
-    args.offline = False  # always streaming
+    if args.offline:
+        input_data["data"][0]["stream"] = [False]
+    elif not input_data["data"][0]["stream"]:
+        args.offline = True
 
     if args.max_tokens:
         input_data["data"][0]["max_tokens"] = [args.max_tokens]


### PR DESCRIPTION
Example output:
```
$ triton model profile -m llama
pull engine()
run_server()
profile()
Warming up...
Warmed up, profiling now...
[ BENCHMARK SUMMARY ]
Prompt size: --
  * Max first token latency: -- ms
  * Min first token latency: -- ms
  * Avg first token latency: -- ms
  * p50 first token latency: -- ms
  * p90 first token latency: -- ms
  * p95 first token latency: -- ms
  * p99 first token latency: -- ms
  * Max generation latency: -- ms
  * Min generation latency: -- ms
  * Avg generation latency: -- ms
  * p50 generation latency: -- ms
  * p90 generation latency: -- ms
  * p95 generation latency: -- ms
  * p99 generation latency: -- ms
  * Avg output token latency: -- ms/output token
  * Avg total token-to-token latency: -- ms
  * Max end-to-end latency: -- ms
  * Min end-to-end latency: -- ms
  * Avg end-to-end latency: -- ms
  * p50 end-to-end latency: -- ms
  * p90 end-to-end latency: -- ms
  * p95 end-to-end latency: -- ms
  * p99 end-to-end latency: -- ms
  * Max end-to-end throughput: -- tokens/s
  * Min end-to-end throughput: -- tokens/s
  * Avg end-to-end throughput: -- tokens/s
  * p50 end-to-end throughput: -- tokens/s
  * p90 end-to-end throughput: -- tokens/s
  * p95 end-to-end throughput: -- tokens/s
  * p99 end-to-end throughput: -- tokens/s
  * Max generation throughput: -- output tokens/s
  * Min generation throughput: -- output tokens/s
  * Avg generation throughput: -- output tokens/s
  * p50 generation throughput: -- output tokens/s
  * p90 generation throughput: -- output tokens/s
  * p95 generation throughput: -- output tokens/s
  * p99 generation throughput: -- output tokens/s
```

cc @nv-hwoo