### PR TITLE
Fix model infer on TRT LLM with negative ints, and minor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Profiling
+generated_input_data.json
+profile_*.json

--- a/src/triton_cli/docker/Dockerfile
+++ b/src/triton_cli/docker/Dockerfile
@@ -1,15 +1,17 @@
 FROM nvcr.io/nvidia/tritonserver:23.12-trtllm-python-py3
 
-# vLLM runtime dependencies
-RUN pip install "vllm==0.2.3"
 # Setup vLLM Triton backend
 RUN mkdir -p /opt/tritonserver/backends/vllm && \
     wget -P /opt/tritonserver/backends/vllm https://raw.githubusercontent.com/triton-inference-server/vllm_backend/main/src/model.py
 
 # TRT-LLM engine build dependencies
-RUN pip install --extra-index-url https://pypi.nvidia.com/ "tensorrt-llm==0.7.0"
+RUN pip install \
+  --extra-index-url https://pypi.nvidia.com/ "tensorrt-llm==0.7.0"
 
-# Mistral support
-RUN pip install "transformers>=4.34.1"
+# vLLM runtime dependencies
+RUN pip install \
+  vllm==0.2.3 \
+  transformers==4.35.2 \
+  accelerate==0.26.1
 
 # TODO: Install Triton CLI in this image

--- a/src/triton_cli/parser.py
+++ b/src/triton_cli/parser.py
@@ -94,6 +94,17 @@ def wait_for_ready(timeout, server, client):
         )
 
 
+def add_verbose_args(subcommands):
+    for subcommand in subcommands:
+        subcommand.add_argument(
+            "-v",
+            "--verbose",
+            action="store_true",
+            default=False,
+            help="Enable verbose logging",
+        )
+
+
 def add_backend_args(subcommands):
     for subcommand in subcommands:
         subcommand.add_argument(
@@ -354,6 +365,7 @@ def parse_args_model(subcommands):
     )
 
     add_profile_args([profile])
+    add_backend_args([profile])
     add_client_args([infer, profile, config, metrics])
     return model
 
@@ -502,14 +514,6 @@ def parse_args_bench(subcommands):
         "bench", help="Run benchmarks on a model loaded into the Triton server."
     )
     bench_run.set_defaults(func=handle_bench)
-    bench_run.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        default=False,
-        help="Enable verbose logging",
-    )
-
     # Conceptually group args for easier visualization
     model_group = bench_run.add_argument_group("model")
     known_models = list(KNOWN_MODEL_SOURCES.keys())
@@ -551,5 +555,6 @@ def parse_args(argv=None):
     _ = parse_args_repo(subcommands)
     _ = parse_args_server(subcommands)
     _ = parse_args_bench(subcommands)
+    add_verbose_args([parser])
     args = parser.parse_args(argv)
     return args


### PR DESCRIPTION
TRT LLM has TYPE_INT32 params like `max_tokens` that can;t be negative, but client script was sending random ints that could be negative. Updated to clamp the values to (0, 128) to try to avoid similar future issues, and added some handling for the TRT LLM args in llm data generator.

Moved verbose to top level arg to be accessible by all subcommands (note: needs `triton -v subcommand ...` 

Tweak versions and order of installs in Dockerfile. I think this fixes accelerate/mistral issues, but didn't check too hard.

```
triton repo add -m llama-2-7b --backend tensorrtllm
triton server start
triton model infer -m llama-2-7b --prompt "Convert the number 71 into words:"
```