### PR TITLE
Minor Repo Optimizations

### DIFF
--- a/src/triton_cli/repository.py
+++ b/src/triton_cli/repository.py
@@ -73,14 +73,14 @@ ENGINE_DEST_PATH = os.environ.get("ENGINE_DEST_PATH", "/tmp/engines")
 HF_TOKEN_PATH = Path.home() / ".cache" / "huggingface" / "token"
 
 SUPPORTED_TRT_LLM_BUILDERS = {
-    "gpt2": GPTBuilder,
-    "meta-llama/Llama-2-7b-hf": LlamaBuilder,
-}
-
-# TODO: Determine minimal set of files needed for each engine builder
-TRT_LLM_BUILDER_IGNORE_PATTERNS = {
-    "gpt2": ["onnx*", "*.bin"],
-    "meta-llama/Llama-2-7b-hf": ["*.bin"],
+    "gpt2": {
+        "builder": GPTBuilder,
+        "hf_allow_patterns": ["*.safetensors", "*.json"],
+    },
+    "meta-llama/Llama-2-7b-hf": {
+        "builder": LlamaBuilder,
+        "hf_allow_patterns": ["*.safetensors", "*.json"],
+    },
 }
 
 
@@ -248,11 +248,15 @@ class ModelRepository:
             raise ValueError("HuggingFace ID must be non-empty")
 
         if backend == "tensorrtllm":
-            Builder = SUPPORTED_TRT_LLM_BUILDERS.get(huggingface_id)
-            if not Builder:
+            builder_info = SUPPORTED_TRT_LLM_BUILDERS.get(huggingface_id)
+            if not builder_info:
                 raise NotImplementedError(
                     f"Building a TRT LLM engine for {huggingface_id} is not currently supported."
                 )
+
+            Builder = builder_info["builder"]
+            hf_allow_patterns = builder_info["hf_allow_patterns"]
+
             engines_path = ENGINE_DEST_PATH + "/" + name
             tokenizer_path = ENGINE_DEST_PATH + "/" + name + "/tokenizer"
 
@@ -262,9 +266,8 @@ class ModelRepository:
                     f"Found existing engine(s) at {engines_path}, skipping build."
                 )
             else:
-                ignore_patterns = TRT_LLM_BUILDER_IGNORE_PATTERNS[huggingface_id]
                 self.__download_hf_model(
-                    huggingface_id, tokenizer_path, ignore_patterns
+                    huggingface_id, tokenizer_path, allow_patterns=hf_allow_patterns
                 )
 
                 builder = Builder(
@@ -297,14 +300,14 @@ class ModelRepository:
                 model_file.write_text(contents)
 
     def __download_hf_model(
-        self, huggingface_id: str, tokenizer_path: str, ignore_patterns: list = []
+        self, huggingface_id: str, tokenizer_path: str, allow_patterns: list = []
     ):
         # Shouldn't require the user to authenticate with HF unless
         # necessary (i.e., the model exists in a gated repo)
         try:
             snapshot_download(
                 huggingface_id,
-                ignore_patterns=ignore_patterns,
+                allow_patterns=allow_patterns,
                 local_dir=tokenizer_path,
             )
         except hf_utils.GatedRepoError:
@@ -314,7 +317,7 @@ class ModelRepository:
                 )
             snapshot_download(
                 huggingface_id,
-                ignore_patterns=ignore_patterns,
+                allow_patterns=allow_patterns,
                 local_dir=tokenizer_path,
                 use_auth_token=True,  # for gated repos like llama
             )


### PR DESCRIPTION
**Goal:** To avoid unnecessarily re-building TRT LLM engines. Also to avoid downloading unnecessary files.

**Steps:**
1. `docker run --rm -it --gpus all -v {PATH}/triton_cli/:/opt/tritonserver/triton_cli triton_llm bash`
2. `cd triton_cli/ && pip install .`
3. `triton repo add -m gpt --source hf:gpt2 --backend tensorrtllm`
4. Repeat: `triton repo add -m gpt --source hf:gpt2 --backend tensorrtllm` --> ERROR repo exists!
5. `triton repo clear`
6. `triton repo add -m gpt --source hf:gpt2 --backend tensorrtllm` --> No build
7. `triton server start` --> successful.