### PR TITLE
Disable Echo in TRT-LLM as Default

### DIFF
--- a/src/triton_cli/trt_llm/engine_config_parser.py
+++ b/src/triton_cli/trt_llm/engine_config_parser.py
@@ -53,6 +53,8 @@ def parse_and_substitute(
         "max_batch_size"
     ]
     config_dict["max_queue_delay_microseconds"] = 1000
+    # Default echo = False
+    config_dict["exclude_input_in_output"] = "True"
     # The following parameters are based on NGC's model requirements
     config_dict["bls_instance_count"] = 1
     config_dict["postprocessing_instance_count"] = 1


### PR DESCRIPTION
Most chat applications / apis (openapi) list echo as default off. Making this change in the template brings that in line. Users can manually change it if needed - but it helps for semi-automated flows. 