### PR TITLE
Update test images to 24.04 and remove duplicate TRT-LLM install

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -36,7 +36,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     container:
-      image: nvcr.io/nvidia/tritonserver:24.01-py3
+      image: nvcr.io/nvidia/tritonserver:24.04-py3
     strategy:
       fail-fast: false
       matrix:

--- a/tests/trtllm-requirements.txt
+++ b/tests/trtllm-requirements.txt
@@ -1,2 +1,5 @@
---extra-index-url https://pypi.nvidia.com/
-tensorrt_llm==0.9.0
+# NOTE: No dependencies needed for running inside 24.04 TRTLLM container at this time
+#       Keeping this around for reference if this changes, but may remove later
+#       when the process is more stabilized.
+# --extra-index-url https://pypi.nvidia.com/
+# tensorrt_llm==0.9.0


### PR DESCRIPTION
- TRTLLM 0.9.0 is already installed in the 24.04 TRTLLM container used for testing
- The upstream pip install will also bring in TensorRT 9.3, but the container seems to have TensorRT 9.2, and this can cause a conflict when loading the engine at runtime. I suspect this is the root cause for this error:
```
[TensorRT-LLM][ERROR] 6: The engine plan file is not compatible with this version of TensorRT, expecting library version 9.2.0.5 got 9.3.0.1, please rebuild.
[TensorRT-LLM][ERROR] 2: [engine.cpp::deserializeEngine::1148] Error Code 2: Internal Error (Assertion engine->deserialize(start, size, allocator, runtime) failed. )
```