### PR TITLE
Tweak test timeouts to account for testing Llama 2 and Llama 3 models

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -61,6 +61,6 @@ jobs:
         ruff format .
     - name: Test with pytest
       run: |
-        pip install pytest pytest-timeout pytest-cov psutil
+        python -m pip install pytest pytest-timeout pytest-cov psutil
         cd tests
-        pytest -v --doctest-modules --junitxml=junit/test-results.xml --cov=triton_cli --cov-report=xml --cov-report=html --ignore-glob=test_models
+        pytest -vv --doctest-modules --junitxml=junit/test-results.xml --cov=triton_cli --cov-report=xml --cov-report=html --ignore-glob=test_models

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -51,16 +51,16 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .
+        python3 -m pip install --upgrade pip
+        python3 -m pip install -e .
         python -c "import triton_cli; print(triton_cli.__version__)"
     - name: Lint and format with ruff
       run: |
-        python -m pip install ruff
+        python3 -m pip install ruff
         ruff check .
         ruff format .
     - name: Test with pytest
       run: |
-        python -m pip install pytest pytest-timeout pytest-cov psutil
+        python3 -m pip install pytest pytest-timeout pytest-cov psutil
         cd tests
         pytest -vv --doctest-modules --junitxml=junit/test-results.xml --cov=triton_cli --cov-report=xml --cov-report=html --ignore-glob=test_models

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -63,4 +63,4 @@ jobs:
       run: |
         pip install pytest pytest-timeout pytest-cov psutil
         cd tests
-        pytest --doctest-modules --junitxml=junit/test-results.xml --cov=triton_cli --cov-report=xml --cov-report=html --ignore-glob=test_models
+        pytest -vv --doctest-modules --junitxml=junit/test-results.xml --cov=triton_cli --cov-report=xml --cov-report=html --ignore-glob=test_models

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -63,4 +63,4 @@ jobs:
       run: |
         pip install pytest pytest-timeout pytest-cov psutil
         cd tests
-        pytest -vv --doctest-modules --junitxml=junit/test-results.xml --cov=triton_cli --cov-report=xml --cov-report=html --ignore-glob=test_models
+        pytest -v --doctest-modules --junitxml=junit/test-results.xml --cov=triton_cli --cov-report=xml --cov-report=html --ignore-glob=test_models

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -129,7 +129,7 @@ class TestE2E:
             ),
         ],
     )
-    @pytest.mark.timeout(600)
+    @pytest.mark.timeout(900)
     def test_vllm_e2e(self, protocol, setup_and_teardown):
         # NOTE: VLLM test models will be passed by the testing infrastructure.
         # Only a single model will be passed per test to enable tests to run concurrently.
@@ -139,7 +139,8 @@ class TestE2E:
         pid = utils.run_server()
         setup_and_teardown.pid = pid
         # vLLM will download the model on the fly, so give it a big timeout
-        utils.wait_for_server_ready(timeout=300)
+        # TODO: Consider mounting larger models pre-downloaded for testing
+        utils.wait_for_server_ready(timeout=600)
 
         self._infer(model, prompt=PROMPT, protocol=protocol)
         self._profile(model, backend="vllm")

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -139,7 +139,10 @@ class TestE2E:
         pid = utils.run_server()
         setup_and_teardown.pid = pid
         # vLLM will download the model on the fly, so give it a big timeout
-        # TODO: Consider mounting larger models pre-downloaded for testing
+        # TODO: Consider one of the following
+        # (a) Pre-download and mount larger models in test environment
+        # (b) Download model from HF for vLLM at import step to remove burden
+        #     from server startup step.
         utils.wait_for_server_ready(timeout=600)
 
         self._infer(model, prompt=PROMPT, protocol=protocol)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -45,7 +45,7 @@ def run_server(repo=None, mode="local"):
     return p.pid
 
 
-def wait_for_server_ready(timeout: int = 30):
+def wait_for_server_ready(timeout: int = 60):
     start = time.time()
     while time.time() - start < timeout:
         print(


### PR DESCRIPTION
- Improve test log verbosity to see what tests get skipped with `pytest -vv`
- Increase timeout for vLLM e2e tests to avoid timing out on Llama2/3 tests that take longer to download
- Add some comments about future improvements to vLLM e2e tests