### PR TITLE
test: Unit Tests for `triton {metrics, config, status}`

### DIFF
--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Trigger Pipeline
         run: |
           #!/bin/bash
-          curl --fail --request POST --form token=${{ secrets.PIPELINE_TOKEN }} -F ref=${GITHUB_HEAD_REF} -F variables[RULE_WORKFLOW]="DS_TEST_TRITON_CLI" "${{ secrets.PIPELINE_URL }}"
+          curl --fail --request POST --form token=${{ secrets.PIPELINE_TOKEN }} -F ref=${GITHUB_HEAD_REF} -F variables[TRITON_CLI_REPO_TAG]=${GITHUB_HEAD_REF} -F variables[RULE_WORKFLOW]="DS_TEST_TRITON_CLI" "${{ secrets.PIPELINE_URL }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ keywords = []
 requires-python = ">=3.10,<4"
 # TODO: Add [gpu] set of dependencies for trtllm once it's available on pypi
 dependencies = [
-    "grpcio>=1.64.0",
     "directory-tree == 0.0.4", # may remove in future
     "docker == 6.1.3",
     "genai-perf @ git+https://github.com/triton-inference-server/client.git@r24.04#subdirectory=src/c++/perf_analyzer/genai-perf",
@@ -58,6 +57,8 @@ dependencies = [
     "psutil >= 5.9.5", # may remove later
     "rich == 13.5.2",
     # TODO: Test on cpu-only machine if [cuda] dependency is an issue
+    # FIXME: Required for latest tritonclient 2.46.0
+    "grpcio>=1.64.0",
     "tritonclient[all] >= 2.45",
     "huggingface-hub >= 0.19.4",
     # Testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ keywords = []
 requires-python = ">=3.10,<4"
 # TODO: Add [gpu] set of dependencies for trtllm once it's available on pypi
 dependencies = [
+    "grpcio>=1.64.0",
     "directory-tree == 0.0.4", # may remove in future
     "docker == 6.1.3",
     "genai-perf @ git+https://github.com/triton-inference-server/client.git@r24.04#subdirectory=src/c++/perf_analyzer/genai-perf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,7 @@ dependencies = [
     "psutil >= 5.9.5", # may remove later
     "rich == 13.5.2",
     # TODO: Test on cpu-only machine if [cuda] dependency is an issue
-    # FIXME: Required for latest tritonclient 2.46.0
-    "grpcio>=1.64.0",
-    "tritonclient[all] >= 2.45",
+    "tritonclient[all] == 2.45.0",
     "huggingface-hub >= 0.19.4",
     # Testing
     "pytest >= 8.1.1", # may remove later

--- a/src/triton_cli/main.py
+++ b/src/triton_cli/main.py
@@ -30,9 +30,17 @@ from triton_cli import parser
 
 import sys
 import logging
+import io
+from contextlib import redirect_stdout
 
 logging.basicConfig(level=logging.INFO, format="%(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger("triton")
+
+
+def run_and_capture_stdout(args):
+    with io.StringIO() as buf, redirect_stdout(buf):
+        run(args)
+        return buf.getvalue()
 
 
 # Separate function that can raise exceptions used for testing

--- a/src/triton_cli/parser.py
+++ b/src/triton_cli/parser.py
@@ -409,7 +409,7 @@ def handle_config(args: argparse.Namespace):
     config = client.get_model_config(args.model)
     if config:
         # TODO: Table
-        rich_print(config)
+        rich_print(json.dumps(config))
 
 
 def handle_status(args: argparse.Namespace):
@@ -422,7 +422,7 @@ def handle_status(args: argparse.Namespace):
 
     health = client.get_server_health()
     if health:
-        print(json.dumps(health))
+        rich_print(json.dumps(health))
 
 
 # Optional argv used for testing - will default to sys.argv if None.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,11 +167,11 @@ class TestRepo:
     def test_triton_metrics(self, model):        
         # Import the Model
         pid = utils.run_server(repo=MODEL_REPO)
-        setup_and_teardown.pid = pid
+        # setup_and_teardown.pid = pid
         utils.wait_for_server_ready()
 
         # infer should work without a prompt for non-LLM models
-        self._infer(model)
+        self._infer(model, prompt=PROMPT)
 
         output = ""
         # Redirect stdout to a buffer to capture the output of the command.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,7 +89,7 @@ class TestRepo:
         args = ["config", "-m", model]
         run(args)
 
-    def _status(self, model):
+    def _status(self):
         args = ["status"]
         run(args)
 
@@ -242,7 +242,7 @@ class TestRepo:
         output = ""
         # Redirect stdout to a buffer to capture the output of the command.
         with io.StringIO() as buf, redirect_stdout(buf):
-            self._status(model)
+            self._status()
             output = buf.getvalue()
         
         print(f"Status: {output}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,7 +211,7 @@ class TestRepo:
         # Loop through all loaded models and check for successful inference
         for loaded_models in metrics["nv_inference_request_success"]["metrics"]:
             if loaded_models["labels"]["model"] == model:
-                assert loaded_models["value"] > 0
+                assert loaded_models["value"] == 1
 
     @pytest.mark.parametrize("model", ["add_sub", "mock_llm"])
     def test_triton_config(self, model, setup_and_teardown):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,3 +139,18 @@ class TestRepo:
         args = parse_args()
         args.func(args)
         mock_run.assert_called_once_with(["genai-perf", "-m", "add_sub"], check=True)
+
+    @pytest.mark.parametrize("model", ["mock_llm"])
+    def test_triton_metrics(self, model):
+        # triton infer -m model
+        # output = triton metrics
+        # result = json.loads(output) 
+        # Check if result[success] == 1
+        # Metrics that can be checked for success:
+        # 1. nv_inference_request_success
+        # 2. nv_inference_count: Number of inferences performed (does not include cached requests)
+        # 3. nv_inference_exec_count: Number of model executions performed (does not include cached requests)
+
+
+    # @pytest.mark.parametrize("model", ["add_sub", "mock_llm"])
+    # def test_triton_config(self, model):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -209,7 +209,9 @@ class TestRepo:
         with io.StringIO() as buf, redirect_stdout(buf):
             self._config(model)
             output = buf.getvalue()
-        
-        output = eval(output) # Evaluates str and converts to dictionary
+
+        output = repr(output)
+        print(output)
+        output = json.loads(output) # Evaluates str and converts to dictionary
         
         assert output["name"] == model

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -142,6 +142,8 @@ class TestRepo:
 
     @pytest.mark.parametrize("model", ["mock_llm"])
     def test_triton_metrics(self, model):
+        print("Passed Here!!!!!!!")
+        pass
         # triton infer -m model
         # output = triton metrics
         # result = json.loads(output) 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,178 +1,178 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
-#  * Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-#  * Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in the
-#    documentation and/or other materials provided with the distribution.
-#  * Neither the name of NVIDIA CORPORATION nor the names of its
-#    contributors may be used to endorse or promote products derived
-#    from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
-# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# # Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# #
+# # Redistribution and use in source and binary forms, with or without
+# # modification, are permitted provided that the following conditions
+# # are met:
+# #  * Redistributions of source code must retain the above copyright
+# #    notice, this list of conditions and the following disclaimer.
+# #  * Redistributions in binary form must reproduce the above copyright
+# #    notice, this list of conditions and the following disclaimer in the
+# #    documentation and/or other materials provided with the distribution.
+# #  * Neither the name of NVIDIA CORPORATION nor the names of its
+# #    contributors may be used to endorse or promote products derived
+# #    from this software without specific prior written permission.
+# #
+# # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# # PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# # CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# # PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# # PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# # OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
-import pytest
-from triton_cli.main import run
-import utils
-
-
-PROMPT = "machine learning is"
-
-TEST_DIR = os.path.dirname(os.path.realpath(__file__))
-MODEL_REPO = os.path.join(TEST_DIR, "test_models")
+# import os
+# import pytest
+# from triton_cli.main import run
+# import utils
 
 
-class TestE2E:
-    def _clear(self):
-        args = ["remove", "-m", "all"]
-        run(args)
+# PROMPT = "machine learning is"
 
-    def _import(self, model, source=None, backend=None, repo=None):
-        args = ["import", "-m", model]
-        if source:
-            args += ["--source", source]
-        if backend:
-            args += ["--backend", backend]
-        if repo:
-            args += ["--repo", repo]
-        run(args)
+# TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+# MODEL_REPO = os.path.join(TEST_DIR, "test_models")
 
-    def _infer(self, model, prompt=None, protocol=None):
-        args = ["infer", "-m", model]
-        if prompt:
-            args += ["--prompt", prompt]
-        if protocol:
-            args += ["-i", protocol]
-        run(args)
 
-    def _profile(self, model, backend):
-        args = ["profile", "-m", model, "--backend", backend]
-        run(args)
+# class TestE2E:
+#     def _clear(self):
+#         args = ["remove", "-m", "all"]
+#         run(args)
 
-    class KillServerByPid:
-        def __init__(self):
-            self.pid = None
+#     def _import(self, model, source=None, backend=None, repo=None):
+#         args = ["import", "-m", model]
+#         if source:
+#             args += ["--source", source]
+#         if backend:
+#             args += ["--backend", backend]
+#         if repo:
+#             args += ["--repo", repo]
+#         run(args)
 
-        def kill_server(self):
-            if self.pid is not None:
-                utils.kill_server(self.pid)
+#     def _infer(self, model, prompt=None, protocol=None):
+#         args = ["infer", "-m", model]
+#         if prompt:
+#             args += ["--prompt", prompt]
+#         if protocol:
+#             args += ["-i", protocol]
+#         run(args)
 
-    @pytest.fixture
-    def setup_and_teardown(self):
-        # Setup before the test case is run.
-        kill_server = self.KillServerByPid()
-        self._clear()
+#     def _profile(self, model, backend):
+#         args = ["profile", "-m", model, "--backend", backend]
+#         run(args)
 
-        yield kill_server
+#     class KillServerByPid:
+#         def __init__(self):
+#             self.pid = None
 
-        # Teardown after the test case is done.
-        kill_server.kill_server()
-        self._clear()
+#         def kill_server(self):
+#             if self.pid is not None:
+#                 utils.kill_server(self.pid)
 
-    @pytest.mark.skipif(
-        os.environ.get("IMAGE_KIND") != "TRTLLM", reason="Only run for TRT-LLM image"
-    )
-    @pytest.mark.parametrize(
-        "protocol",
-        [
-            "grpc",
-            pytest.param(
-                "http",
-                # NOTE: skip because xfail was causing server to not get cleaned up by test in background
-                marks=pytest.mark.skip(
-                    reason="http does not support model infer and model profile for decoupled models"
-                ),
-            ),
-        ],
-    )
-    @pytest.mark.timeout(600)
-    def test_tensorrtllm_e2e(self, protocol, setup_and_teardown):
-        # NOTE: TRTLLM test models will be passed by the testing infrastructure.
-        # Only a single model will be passed per test to enable tests to run concurrently.
-        model = os.environ.get("TRTLLM_MODEL")
-        assert model is not None, "TRTLLM_MODEL env var must be set!"
-        self._import(model, backend="tensorrtllm")
-        pid = utils.run_server()
-        setup_and_teardown.pid = pid
-        utils.wait_for_server_ready()
+#     @pytest.fixture
+#     def setup_and_teardown(self):
+#         # Setup before the test case is run.
+#         kill_server = self.KillServerByPid()
+#         self._clear()
 
-        self._infer(model, prompt=PROMPT, protocol=protocol)
-        self._profile(model, backend="tensorrtllm")
+#         yield kill_server
 
-    @pytest.mark.skipif(
-        os.environ.get("IMAGE_KIND") != "VLLM", reason="Only run for VLLM image"
-    )
-    @pytest.mark.parametrize(
-        "protocol",
-        [
-            "grpc",
-            pytest.param(
-                "http",
-                # NOTE: skip because xfail was causing server to not get cleaned up by test in background
-                marks=pytest.mark.skip(
-                    reason="http not supported decoupled models and model profiling yet"
-                ),
-            ),
-        ],
-    )
-    @pytest.mark.timeout(900)
-    def test_vllm_e2e(self, protocol, setup_and_teardown):
-        # NOTE: VLLM test models will be passed by the testing infrastructure.
-        # Only a single model will be passed per test to enable tests to run concurrently.
-        model = os.environ.get("VLLM_MODEL")
-        assert model is not None, "VLLM_MODEL env var must be set!"
-        self._import(model)
-        pid = utils.run_server()
-        setup_and_teardown.pid = pid
-        # vLLM will download the model on the fly, so give it a big timeout
-        # TODO: Consider one of the following
-        # (a) Pre-download and mount larger models in test environment
-        # (b) Download model from HF for vLLM at import step to remove burden
-        #     from server startup step.
-        utils.wait_for_server_ready(timeout=600)
+#         # Teardown after the test case is done.
+#         kill_server.kill_server()
+#         self._clear()
 
-        self._infer(model, prompt=PROMPT, protocol=protocol)
-        self._profile(model, backend="vllm")
+#     @pytest.mark.skipif(
+#         os.environ.get("IMAGE_KIND") != "TRTLLM", reason="Only run for TRT-LLM image"
+#     )
+#     @pytest.mark.parametrize(
+#         "protocol",
+#         [
+#             "grpc",
+#             pytest.param(
+#                 "http",
+#                 # NOTE: skip because xfail was causing server to not get cleaned up by test in background
+#                 marks=pytest.mark.skip(
+#                     reason="http does not support model infer and model profile for decoupled models"
+#                 ),
+#             ),
+#         ],
+#     )
+#     @pytest.mark.timeout(600)
+#     def test_tensorrtllm_e2e(self, protocol, setup_and_teardown):
+#         # NOTE: TRTLLM test models will be passed by the testing infrastructure.
+#         # Only a single model will be passed per test to enable tests to run concurrently.
+#         model = os.environ.get("TRTLLM_MODEL")
+#         assert model is not None, "TRTLLM_MODEL env var must be set!"
+#         self._import(model, backend="tensorrtllm")
+#         pid = utils.run_server()
+#         setup_and_teardown.pid = pid
+#         utils.wait_for_server_ready()
 
-    @pytest.mark.parametrize("protocol", ["grpc", "http"])
-    def test_non_llm(self, protocol, setup_and_teardown):
-        # This test runs on the default Triton image, as well as on both TRT-LLM and VLLM images.
-        # Use the existing models.
-        pid = utils.run_server(repo=MODEL_REPO)
-        setup_and_teardown.pid = pid
-        utils.wait_for_server_ready()
+#         self._infer(model, prompt=PROMPT, protocol=protocol)
+#         self._profile(model, backend="tensorrtllm")
 
-        model = "add_sub"
-        # infer should work without a prompt for non-LLM models
-        self._infer(model, protocol=protocol)
+#     @pytest.mark.skipif(
+#         os.environ.get("IMAGE_KIND") != "VLLM", reason="Only run for VLLM image"
+#     )
+#     @pytest.mark.parametrize(
+#         "protocol",
+#         [
+#             "grpc",
+#             pytest.param(
+#                 "http",
+#                 # NOTE: skip because xfail was causing server to not get cleaned up by test in background
+#                 marks=pytest.mark.skip(
+#                     reason="http not supported decoupled models and model profiling yet"
+#                 ),
+#             ),
+#         ],
+#     )
+#     @pytest.mark.timeout(900)
+#     def test_vllm_e2e(self, protocol, setup_and_teardown):
+#         # NOTE: VLLM test models will be passed by the testing infrastructure.
+#         # Only a single model will be passed per test to enable tests to run concurrently.
+#         model = os.environ.get("VLLM_MODEL")
+#         assert model is not None, "VLLM_MODEL env var must be set!"
+#         self._import(model)
+#         pid = utils.run_server()
+#         setup_and_teardown.pid = pid
+#         # vLLM will download the model on the fly, so give it a big timeout
+#         # TODO: Consider one of the following
+#         # (a) Pre-download and mount larger models in test environment
+#         # (b) Download model from HF for vLLM at import step to remove burden
+#         #     from server startup step.
+#         utils.wait_for_server_ready(timeout=600)
 
-    @pytest.mark.parametrize("protocol", ["grpc", "http"])
-    def test_mock_llm(self, protocol, setup_and_teardown):
-        # This test runs on the default Triton image, as well as on both TRT-LLM and VLLM images.
-        # Use the existing models.
-        pid = utils.run_server(repo=MODEL_REPO)
-        setup_and_teardown.pid = pid
-        utils.wait_for_server_ready()
+#         self._infer(model, prompt=PROMPT, protocol=protocol)
+#         self._profile(model, backend="vllm")
 
-        model = "mock_llm"
-        # infer should work with a prompt for LLM models
-        self._infer(model, prompt=PROMPT, protocol=protocol)
-        # infer should fail without a prompt for LLM models
-        with pytest.raises(Exception):
-            self._infer(model, protocol=protocol)
-        # profile should work without a prompt for LLM models
-        self._profile(model, backend="tensorrtllm")
+#     @pytest.mark.parametrize("protocol", ["grpc", "http"])
+#     def test_non_llm(self, protocol, setup_and_teardown):
+#         # This test runs on the default Triton image, as well as on both TRT-LLM and VLLM images.
+#         # Use the existing models.
+#         pid = utils.run_server(repo=MODEL_REPO)
+#         setup_and_teardown.pid = pid
+#         utils.wait_for_server_ready()
+
+#         model = "add_sub"
+#         # infer should work without a prompt for non-LLM models
+#         self._infer(model, protocol=protocol)
+
+#     @pytest.mark.parametrize("protocol", ["grpc", "http"])
+#     def test_mock_llm(self, protocol, setup_and_teardown):
+#         # This test runs on the default Triton image, as well as on both TRT-LLM and VLLM images.
+#         # Use the existing models.
+#         pid = utils.run_server(repo=MODEL_REPO)
+#         setup_and_teardown.pid = pid
+#         utils.wait_for_server_ready()
+
+#         model = "mock_llm"
+#         # infer should work with a prompt for LLM models
+#         self._infer(model, prompt=PROMPT, protocol=protocol)
+#         # infer should fail without a prompt for LLM models
+#         with pytest.raises(Exception):
+#             self._infer(model, protocol=protocol)
+#         # profile should work without a prompt for LLM models
+#         self._profile(model, backend="tensorrtllm")

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,178 +1,178 @@
-# # Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# #
-# # Redistribution and use in source and binary forms, with or without
-# # modification, are permitted provided that the following conditions
-# # are met:
-# #  * Redistributions of source code must retain the above copyright
-# #    notice, this list of conditions and the following disclaimer.
-# #  * Redistributions in binary form must reproduce the above copyright
-# #    notice, this list of conditions and the following disclaimer in the
-# #    documentation and/or other materials provided with the distribution.
-# #  * Neither the name of NVIDIA CORPORATION nor the names of its
-# #    contributors may be used to endorse or promote products derived
-# #    from this software without specific prior written permission.
-# #
-# # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
-# # EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# # PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-# # CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-# # EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-# # PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-# # PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-# # OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# import os
-# import pytest
-# from triton_cli.main import run
-# import utils
-
-
-# PROMPT = "machine learning is"
-
-# TEST_DIR = os.path.dirname(os.path.realpath(__file__))
-# MODEL_REPO = os.path.join(TEST_DIR, "test_models")
+import os
+import pytest
+from triton_cli.main import run
+import utils
 
 
-# class TestE2E:
-#     def _clear(self):
-#         args = ["remove", "-m", "all"]
-#         run(args)
+PROMPT = "machine learning is"
 
-#     def _import(self, model, source=None, backend=None, repo=None):
-#         args = ["import", "-m", model]
-#         if source:
-#             args += ["--source", source]
-#         if backend:
-#             args += ["--backend", backend]
-#         if repo:
-#             args += ["--repo", repo]
-#         run(args)
+TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+MODEL_REPO = os.path.join(TEST_DIR, "test_models")
 
-#     def _infer(self, model, prompt=None, protocol=None):
-#         args = ["infer", "-m", model]
-#         if prompt:
-#             args += ["--prompt", prompt]
-#         if protocol:
-#             args += ["-i", protocol]
-#         run(args)
 
-#     def _profile(self, model, backend):
-#         args = ["profile", "-m", model, "--backend", backend]
-#         run(args)
+class TestE2E:
+    def _clear(self):
+        args = ["remove", "-m", "all"]
+        run(args)
 
-#     class KillServerByPid:
-#         def __init__(self):
-#             self.pid = None
+    def _import(self, model, source=None, backend=None, repo=None):
+        args = ["import", "-m", model]
+        if source:
+            args += ["--source", source]
+        if backend:
+            args += ["--backend", backend]
+        if repo:
+            args += ["--repo", repo]
+        run(args)
 
-#         def kill_server(self):
-#             if self.pid is not None:
-#                 utils.kill_server(self.pid)
+    def _infer(self, model, prompt=None, protocol=None):
+        args = ["infer", "-m", model]
+        if prompt:
+            args += ["--prompt", prompt]
+        if protocol:
+            args += ["-i", protocol]
+        run(args)
 
-#     @pytest.fixture
-#     def setup_and_teardown(self):
-#         # Setup before the test case is run.
-#         kill_server = self.KillServerByPid()
-#         self._clear()
+    def _profile(self, model, backend):
+        args = ["profile", "-m", model, "--backend", backend]
+        run(args)
 
-#         yield kill_server
+    class KillServerByPid:
+        def __init__(self):
+            self.pid = None
 
-#         # Teardown after the test case is done.
-#         kill_server.kill_server()
-#         self._clear()
+        def kill_server(self):
+            if self.pid is not None:
+                utils.kill_server(self.pid)
 
-#     @pytest.mark.skipif(
-#         os.environ.get("IMAGE_KIND") != "TRTLLM", reason="Only run for TRT-LLM image"
-#     )
-#     @pytest.mark.parametrize(
-#         "protocol",
-#         [
-#             "grpc",
-#             pytest.param(
-#                 "http",
-#                 # NOTE: skip because xfail was causing server to not get cleaned up by test in background
-#                 marks=pytest.mark.skip(
-#                     reason="http does not support model infer and model profile for decoupled models"
-#                 ),
-#             ),
-#         ],
-#     )
-#     @pytest.mark.timeout(600)
-#     def test_tensorrtllm_e2e(self, protocol, setup_and_teardown):
-#         # NOTE: TRTLLM test models will be passed by the testing infrastructure.
-#         # Only a single model will be passed per test to enable tests to run concurrently.
-#         model = os.environ.get("TRTLLM_MODEL")
-#         assert model is not None, "TRTLLM_MODEL env var must be set!"
-#         self._import(model, backend="tensorrtllm")
-#         pid = utils.run_server()
-#         setup_and_teardown.pid = pid
-#         utils.wait_for_server_ready()
+    @pytest.fixture
+    def setup_and_teardown(self):
+        # Setup before the test case is run.
+        kill_server = self.KillServerByPid()
+        self._clear()
 
-#         self._infer(model, prompt=PROMPT, protocol=protocol)
-#         self._profile(model, backend="tensorrtllm")
+        yield kill_server
 
-#     @pytest.mark.skipif(
-#         os.environ.get("IMAGE_KIND") != "VLLM", reason="Only run for VLLM image"
-#     )
-#     @pytest.mark.parametrize(
-#         "protocol",
-#         [
-#             "grpc",
-#             pytest.param(
-#                 "http",
-#                 # NOTE: skip because xfail was causing server to not get cleaned up by test in background
-#                 marks=pytest.mark.skip(
-#                     reason="http not supported decoupled models and model profiling yet"
-#                 ),
-#             ),
-#         ],
-#     )
-#     @pytest.mark.timeout(900)
-#     def test_vllm_e2e(self, protocol, setup_and_teardown):
-#         # NOTE: VLLM test models will be passed by the testing infrastructure.
-#         # Only a single model will be passed per test to enable tests to run concurrently.
-#         model = os.environ.get("VLLM_MODEL")
-#         assert model is not None, "VLLM_MODEL env var must be set!"
-#         self._import(model)
-#         pid = utils.run_server()
-#         setup_and_teardown.pid = pid
-#         # vLLM will download the model on the fly, so give it a big timeout
-#         # TODO: Consider one of the following
-#         # (a) Pre-download and mount larger models in test environment
-#         # (b) Download model from HF for vLLM at import step to remove burden
-#         #     from server startup step.
-#         utils.wait_for_server_ready(timeout=600)
+        # Teardown after the test case is done.
+        kill_server.kill_server()
+        self._clear()
 
-#         self._infer(model, prompt=PROMPT, protocol=protocol)
-#         self._profile(model, backend="vllm")
+    @pytest.mark.skipif(
+        os.environ.get("IMAGE_KIND") != "TRTLLM", reason="Only run for TRT-LLM image"
+    )
+    @pytest.mark.parametrize(
+        "protocol",
+        [
+            "grpc",
+            pytest.param(
+                "http",
+                # NOTE: skip because xfail was causing server to not get cleaned up by test in background
+                marks=pytest.mark.skip(
+                    reason="http does not support model infer and model profile for decoupled models"
+                ),
+            ),
+        ],
+    )
+    @pytest.mark.timeout(600)
+    def test_tensorrtllm_e2e(self, protocol, setup_and_teardown):
+        # NOTE: TRTLLM test models will be passed by the testing infrastructure.
+        # Only a single model will be passed per test to enable tests to run concurrently.
+        model = os.environ.get("TRTLLM_MODEL")
+        assert model is not None, "TRTLLM_MODEL env var must be set!"
+        self._import(model, backend="tensorrtllm")
+        pid = utils.run_server()
+        setup_and_teardown.pid = pid
+        utils.wait_for_server_ready()
 
-#     @pytest.mark.parametrize("protocol", ["grpc", "http"])
-#     def test_non_llm(self, protocol, setup_and_teardown):
-#         # This test runs on the default Triton image, as well as on both TRT-LLM and VLLM images.
-#         # Use the existing models.
-#         pid = utils.run_server(repo=MODEL_REPO)
-#         setup_and_teardown.pid = pid
-#         utils.wait_for_server_ready()
+        self._infer(model, prompt=PROMPT, protocol=protocol)
+        self._profile(model, backend="tensorrtllm")
 
-#         model = "add_sub"
-#         # infer should work without a prompt for non-LLM models
-#         self._infer(model, protocol=protocol)
+    @pytest.mark.skipif(
+        os.environ.get("IMAGE_KIND") != "VLLM", reason="Only run for VLLM image"
+    )
+    @pytest.mark.parametrize(
+        "protocol",
+        [
+            "grpc",
+            pytest.param(
+                "http",
+                # NOTE: skip because xfail was causing server to not get cleaned up by test in background
+                marks=pytest.mark.skip(
+                    reason="http not supported decoupled models and model profiling yet"
+                ),
+            ),
+        ],
+    )
+    @pytest.mark.timeout(900)
+    def test_vllm_e2e(self, protocol, setup_and_teardown):
+        # NOTE: VLLM test models will be passed by the testing infrastructure.
+        # Only a single model will be passed per test to enable tests to run concurrently.
+        model = os.environ.get("VLLM_MODEL")
+        assert model is not None, "VLLM_MODEL env var must be set!"
+        self._import(model)
+        pid = utils.run_server()
+        setup_and_teardown.pid = pid
+        # vLLM will download the model on the fly, so give it a big timeout
+        # TODO: Consider one of the following
+        # (a) Pre-download and mount larger models in test environment
+        # (b) Download model from HF for vLLM at import step to remove burden
+        #     from server startup step.
+        utils.wait_for_server_ready(timeout=600)
 
-#     @pytest.mark.parametrize("protocol", ["grpc", "http"])
-#     def test_mock_llm(self, protocol, setup_and_teardown):
-#         # This test runs on the default Triton image, as well as on both TRT-LLM and VLLM images.
-#         # Use the existing models.
-#         pid = utils.run_server(repo=MODEL_REPO)
-#         setup_and_teardown.pid = pid
-#         utils.wait_for_server_ready()
+        self._infer(model, prompt=PROMPT, protocol=protocol)
+        self._profile(model, backend="vllm")
 
-#         model = "mock_llm"
-#         # infer should work with a prompt for LLM models
-#         self._infer(model, prompt=PROMPT, protocol=protocol)
-#         # infer should fail without a prompt for LLM models
-#         with pytest.raises(Exception):
-#             self._infer(model, protocol=protocol)
-#         # profile should work without a prompt for LLM models
-#         self._profile(model, backend="tensorrtllm")
+    @pytest.mark.parametrize("protocol", ["grpc", "http"])
+    def test_non_llm(self, protocol, setup_and_teardown):
+        # This test runs on the default Triton image, as well as on both TRT-LLM and VLLM images.
+        # Use the existing models.
+        pid = utils.run_server(repo=MODEL_REPO)
+        setup_and_teardown.pid = pid
+        utils.wait_for_server_ready()
+
+        model = "add_sub"
+        # infer should work without a prompt for non-LLM models
+        self._infer(model, protocol=protocol)
+
+    @pytest.mark.parametrize("protocol", ["grpc", "http"])
+    def test_mock_llm(self, protocol, setup_and_teardown):
+        # This test runs on the default Triton image, as well as on both TRT-LLM and VLLM images.
+        # Use the existing models.
+        pid = utils.run_server(repo=MODEL_REPO)
+        setup_and_teardown.pid = pid
+        utils.wait_for_server_ready()
+
+        model = "mock_llm"
+        # infer should work with a prompt for LLM models
+        self._infer(model, prompt=PROMPT, protocol=protocol)
+        # infer should fail without a prompt for LLM models
+        with pytest.raises(Exception):
+            self._infer(model, protocol=protocol)
+        # profile should work without a prompt for LLM models
+        self._profile(model, backend="tensorrtllm")


### PR DESCRIPTION
This PR is raised to address [Jira Ticket [DLIS-6264]](https://jirasw.nvidia.com/browse/DLIS-6264). 

Unit tests have been added primarily within `triton_cli/tests/test_cli.py` for `triton metrics`, `triton config`, and `triton status`.

Brief overview of the tests:
For **metrics**:
- From the `test_models` repository, `mock_llm` is loaded. 
- Individual inferences are performed on each model
- `triton metrics` output checked to see if `nv_inference_request_success` reflects successful inference.

For **config**:
- From the `test_models` repository, `add_sub` and `mock_llm` are loaded. 
- `triton config -m model_name` is called.
- The `name` field of the returned `json` is cross-referenced with the original `model_name`

For **status**:
- From the `test_models` repository, `add_sub` and `mock_llm` are loaded. 
- `triton status` is called and verifies from output that the models are `live` and `ready`.

Secondary Changes that were made while implementing the tests:
1. Adding `grpcio>=1.64.0` to `pyproject.toml`. 
2. Standardizing JSON outputs returned by `triton_cli`: Triton commands were previously returning keys in single quotes and boolean values as `{True, False}` instead of `{true,false}`. This leads to errors when the output is attempted to be parsed as a json. 