### PR TITLE
chore: Upgrade dependencies for 24.05

### DIFF
--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Trigger Pipeline
         run: |
           #!/bin/bash
-          curl --fail --request POST --form token=${{ secrets.PIPELINE_TOKEN }} -F ref=${GITHUB_HEAD_REF} -F variables[RULE_WORKFLOW]="DS_TEST_TRITON_CLI" "${{ secrets.PIPELINE_URL }}"
+          curl --fail --request POST --form token=${{ secrets.PIPELINE_TOKEN }} -F ref=${GITHUB_HEAD_REF} -F variables[TRITON_CLI_REPO_TAG]=${GITHUB_HEAD_REF} -F variables[RULE_WORKFLOW]="DS_TEST_TRITON_CLI" "${{ secrets.PIPELINE_URL }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,10 @@ keywords = []
 requires-python = ">=3.10,<4"
 # TODO: Add [gpu] set of dependencies for trtllm once it's available on pypi
 dependencies = [
+    "grpcio>=1.64.0",
     "directory-tree == 0.0.4", # may remove in future
     "docker == 6.1.3",
-    "genai-perf @ git+https://github.com/triton-inference-server/client.git@r24.04#subdirectory=src/c++/perf_analyzer/genai-perf",
+    "genai-perf @ git+https://github.com/triton-inference-server/client.git@r24.05#subdirectory=src/c++/perf_analyzer/genai-perf",
     # TODO: rely on tritonclient to pull in protobuf and numpy dependencies?
     "numpy >= 1.21",
     "protobuf>=3.7.0",
@@ -57,7 +58,7 @@ dependencies = [
     "psutil >= 5.9.5", # may remove later
     "rich == 13.5.2",
     # TODO: Test on cpu-only machine if [cuda] dependency is an issue
-    "tritonclient[all] >= 2.45",
+    "tritonclient[all] >= 2.46",
     "huggingface-hub >= 0.19.4",
     # Testing
     "pytest >= 8.1.1", # may remove later

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,12 +57,8 @@ dependencies = [
     "prometheus-client == 0.19.0",
     "psutil >= 5.9.5", # may remove later
     "rich == 13.5.2",
-    # TODO: Test on cpu-only machine if [cuda] dependency is an issue
-<<<<<<< kprashanth-dependency-fix
+    # TODO: Test on cpu-only machine if [cuda] dependency is an issue,
     "tritonclient[all] >= 2.46",
-=======
-    "tritonclient[all] == 2.45.0",
->>>>>>> main
     "huggingface-hub >= 0.19.4",
     # Testing
     "pytest >= 8.1.1", # may remove later

--- a/src/triton_cli/profile.py
+++ b/src/triton_cli/profile.py
@@ -50,7 +50,7 @@ def build_command(args: argparse.Namespace, executable: str):
         # Once GenAI-Perf releases 24.05, "tensorrtllm" as the backend value
         # will be supported by default.
         elif arg == "backend" and value in ["tensorrtllm", "trtllm"]:
-            cmd += ["--backend", "trtllm"]
+            cmd += ["--backend", "tensorrtllm"]
         else:
             if len(arg) == 1:
                 cmd += [f"-{arg}", f"{value}"]


### PR DESCRIPTION
Fixes an existing `grpcio` dependency error introduced in 24.05, and bumps genai-perf and tritonclient versions to 24.05. 

For more information, refer to this [PR comment](https://github.com/triton-inference-server/triton_cli/pull/66#discussion_r1619613997)