### PR TITLE
refactor: Simplify testing with ScopedTritonServer instead of pytest fixtures

### DIFF
--- a/src/triton_cli/main.py
+++ b/src/triton_cli/main.py
@@ -30,17 +30,9 @@ from triton_cli import parser
 
 import sys
 import logging
-import io
-from contextlib import redirect_stdout
 
 logging.basicConfig(level=logging.INFO, format="%(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger("triton")
-
-
-def run_and_capture_stdout(args):
-    with io.StringIO() as buf, redirect_stdout(buf):
-        run(args)
-        return buf.getvalue()
 
 
 # Separate function that can raise exceptions used for testing

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,10 +26,8 @@
 
 import os
 import pytest
-from triton_cli.main import run, run_and_capture_stdout
 from triton_cli.parser import KNOWN_MODEL_SOURCES, parse_args
-import utils
-import json
+from utils import TritonCommands, ScopedTritonServer
 
 KNOWN_MODELS = KNOWN_MODEL_SOURCES.keys()
 KNOWN_SOURCES = KNOWN_MODEL_SOURCES.values()
@@ -50,80 +48,31 @@ MODEL_REPO = os.path.join(TEST_DIR, "test_models")
 
 
 class TestRepo:
-    def _list(self, repo=None):
-        args = ["list"]
-        if repo:
-            args += ["--repo", repo]
-        run(args)
-
-    def _clear(self, repo=None):
-        args = ["remove", "-m", "all"]
-        run(args)
-
-    def _import(self, model, source=None, repo=None, backend=None):
-        args = ["import", "-m", model]
-        if source:
-            args += ["--source", source]
-        if repo:
-            args += ["--repo", repo]
-        if backend:
-            args += ["--backend", backend]
-        run(args)
-
-    def _infer(self, model, prompt=None, protocol=None):
-        args = ["infer", "-m", model]
-        if prompt:
-            args += ["--prompt", prompt]
-        if protocol:
-            args += ["-i", protocol]
-        run(args)
-
-    def _metrics(self):
-        args = ["metrics"]
-        output = run_and_capture_stdout(args)
-        return json.loads(output)
-
-    def _config(self, model):
-        args = ["config", "-m", model]
-        output = run_and_capture_stdout(args)
-        return json.loads(output)
-
-    def _status(self):
-        args = ["status"]
-        output = run_and_capture_stdout(args)
-        return json.loads(output)
-
-    def _remove(self, model, repo=None):
-        args = ["remove", "-m", model]
-        if repo:
-            args += ["--repo", repo]
-        run(args)
-
     @pytest.mark.parametrize("repo", TEST_REPOS)
     def test_clear(self, repo):
-        self._clear(repo)
+        TritonCommands._clear(repo)
 
     # TODO: Add pre/post repo clear to a fixture for setup/teardown
     @pytest.mark.parametrize("model", KNOWN_MODELS)
     @pytest.mark.parametrize("repo", TEST_REPOS)
     def test_import_known_model(self, model, repo):
-        self._clear(repo)
-        self._import(model, repo=repo)
-        self._clear(repo)
+        TritonCommands._clear(repo)
+        TritonCommands._import(model, repo=repo)
+        TritonCommands._clear(repo)
 
     @pytest.mark.parametrize("source", KNOWN_SOURCES)
     @pytest.mark.parametrize("repo", TEST_REPOS)
     def test_import_known_source(self, source, repo):
-        self._clear(repo)
-        self._import("known_source", source=source, repo=repo)
-        self._clear(repo)
+        TritonCommands._clear(repo)
+        TritonCommands._import("known_source", source=source, repo=repo)
+        TritonCommands._clear(repo)
 
     @pytest.mark.parametrize("model,source", CUSTOM_VLLM_MODEL_SOURCES)
     def test_import_vllm(self, model, source):
-        self._clear()
-        self._import(model, source=source)
+        TritonCommands._clear()
+        TritonCommands._import(model, source=source)
         # TODO: Parse repo to find model, with vllm backend in config
-        self._clear()
+        TritonCommands._clear()
 
     @pytest.mark.skipif(
         os.environ.get("IMAGE_KIND") != "TRTLLM", reason="Only run for TRT-LLM image"
@@ -131,9 +80,9 @@ class TestRepo:
     @pytest.mark.parametrize("model,source", CUSTOM_TRTLLM_MODEL_SOURCES)
     def test_repo_add_trtllm_build(self, model, source):
         # TODO: Parse repo to find TRT-LLM models and backend in config
-        self._clear()
-        self._import(model, source=source, backend="tensorrtllm")
-        self._clear()
+        TritonCommands._clear()
+        TritonCommands._import(model, source=source, backend="tensorrtllm")
+        TritonCommands._clear()
 
     @pytest.mark.skip(reason="Pre-built TRT-LLM engines not available")
     def test_import_trtllm_prebuilt(self, model, source):
@@ -145,21 +94,21 @@ class TestRepo:
         with pytest.raises(
             Exception, match="Please use a known model, or provide a --source"
         ):
-            self._import("no_source", source=None)
+            TritonCommands._import("no_source", source=None)
 
     def test_remove(self):
-        self._import("gpt2", source="hf:gpt2")
-        self._remove("gpt2")
+        TritonCommands._import("gpt2", source="hf:gpt2")
+        TritonCommands._remove("gpt2")
 
     # TODO: Find a way to raise well-typed errors for testing purposes, without
     # always dumping traceback to user-facing output.
     def test_remove_nonexistent(self):
         with pytest.raises(FileNotFoundError, match="No model folder exists"):
-            self._remove("does-not-exist")
+            TritonCommands._remove("does-not-exist")
 
     @pytest.mark.parametrize("repo", TEST_REPOS)
     def test_list(self, repo):
-        self._list(repo)
+        TritonCommands._list(repo)
 
     # This test uses mock system args and a mock subprocess call
     # to ensure that the correct subprocess call is made for profile.
@@ -174,8 +123,8 @@ class TestRepo:
     @pytest.mark.parametrize("model", ["mock_llm"])
     def test_triton_metrics(self, model):
         # Import the Model Repo
-        with utils.ScopedTritonServer(repo=MODEL_REPO):
-            metrics_before = self._metrics()
+        with ScopedTritonServer(repo=MODEL_REPO):
+            metrics_before = TritonCommands._metrics()
 
             # Before Inference, Verifying Inference Count == 0
             for loaded_models in metrics_before["nv_inference_request_success"][
@@ -185,9 +134,9 @@ class TestRepo:
                     assert loaded_models["value"] == 0
 
             # Model Inference
-            self._infer(model, prompt=PROMPT)
+            TritonCommands._infer(model, prompt=PROMPT)
 
-            metrics_after = self._metrics()
+            metrics_after = TritonCommands._metrics()
 
             # After Inference, Verifying Inference Count == 1
             for loaded_models in metrics_after["nv_inference_request_success"][
@@ -199,15 +148,15 @@ class TestRepo:
     @pytest.mark.parametrize("model", ["mock_llm"])
     def test_triton_config(self, model):
         # Import the Model
-        with utils.ScopedTritonServer(repo=MODEL_REPO):
-            config = self._config(model)
+        with ScopedTritonServer(repo=MODEL_REPO):
+            config = TritonCommands._config(model)
             # Checks if correct model is loaded
             assert config["name"] == model
 
     @pytest.mark.parametrize("model", ["mock_llm"])
     def test_triton_status(self, model):
         # Import the Model
-        with utils.ScopedTritonServer(repo=MODEL_REPO):
-            status = self._status()
+        with ScopedTritonServer(repo=MODEL_REPO):
+            status = TritonCommands._status(protocol="grpc")
             # Checks if model(s) are live and ready
             assert status["live"] and status["ready"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,7 +174,7 @@ class TestRepo:
     @pytest.mark.parametrize("model", ["mock_llm"])
     def test_triton_metrics(self, model):
         # Import the Model Repo
-        with utils.MockServer(MODEL_REPO) as _:
+        with utils.MockServer(repo=MODEL_REPO) as _:
             metrics_before = self._metrics()
 
             # Before Inference, Verifying Inference Count == 0
@@ -199,7 +199,7 @@ class TestRepo:
     @pytest.mark.parametrize("model", ["mock_llm"])
     def test_triton_config(self, model):
         # Import the Model
-        with utils.MockServer(MODEL_REPO) as _:
+        with utils.MockServer(repo=MODEL_REPO) as _:
             config = self._config(model)
             # Checks if correct model is loaded
             assert config["name"] == model
@@ -207,7 +207,7 @@ class TestRepo:
     @pytest.mark.parametrize("model", ["mock_llm"])
     def test_triton_status(self, model):
         # Import the Model
-        with utils.MockServer(MODEL_REPO) as _:
+        with utils.MockServer(repo=MODEL_REPO) as _:
             status = self._status()
             # Checks if model(s) are live and ready
             assert status["live"] and status["ready"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,7 +174,7 @@ class TestRepo:
     @pytest.mark.parametrize("model", ["mock_llm"])
     def test_triton_metrics(self, model):
         # Import the Model Repo
-        with utils.MockServer(repo=MODEL_REPO) as _:
+        with utils.ScopedTritonServer(repo=MODEL_REPO):
             metrics_before = self._metrics()
 
             # Before Inference, Verifying Inference Count == 0
@@ -199,7 +199,7 @@ class TestRepo:
     @pytest.mark.parametrize("model", ["mock_llm"])
     def test_triton_config(self, model):
         # Import the Model
-        with utils.MockServer(repo=MODEL_REPO) as _:
+        with utils.ScopedTritonServer(repo=MODEL_REPO):
             config = self._config(model)
             # Checks if correct model is loaded
             assert config["name"] == model
@@ -207,7 +207,7 @@ class TestRepo:
     @pytest.mark.parametrize("model", ["mock_llm"])
     def test_triton_status(self, model):
         # Import the Model
-        with utils.MockServer(repo=MODEL_REPO) as _:
+        with utils.ScopedTritonServer(repo=MODEL_REPO):
             status = self._status()
             # Checks if model(s) are live and ready
             assert status["live"] and status["ready"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -189,7 +189,7 @@ class TestRepo:
 
             metrics_after = self._metrics()
 
-            # After Inference, Verifying Inference Count == 0
+            # After Inference, Verifying Inference Count == 1
             for loaded_models in metrics_after["nv_inference_request_success"][
                 "metrics"
             ]:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -86,7 +86,7 @@ class TestE2E:
         model = os.environ.get("TRTLLM_MODEL")
         assert model is not None, "TRTLLM_MODEL env var must be set!"
         self._import(model, backend="tensorrtllm")
-        with utils.ScopedTritonServer() as _:
+        with utils.ScopedTritonServer():
             self._infer(model, prompt=PROMPT, protocol=protocol)
             self._profile(model, backend="tensorrtllm")
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -80,13 +80,13 @@ class TestE2E:
         ],
     )
     @pytest.mark.timeout(600)
-    def test_tensorrtllm_e2e(self, protocol, setup_and_teardown):
+    def test_tensorrtllm_e2e(self, protocol):
         # NOTE: TRTLLM test models will be passed by the testing infrastructure.
         # Only a single model will be passed per test to enable tests to run concurrently.
         model = os.environ.get("TRTLLM_MODEL")
         assert model is not None, "TRTLLM_MODEL env var must be set!"
         self._import(model, backend="tensorrtllm")
-        with utils.MockServer() as _:
+        with utils.ScopedTritonServer() as _:
             self._infer(model, prompt=PROMPT, protocol=protocol)
             self._profile(model, backend="tensorrtllm")
 
@@ -113,7 +113,7 @@ class TestE2E:
         model = os.environ.get("VLLM_MODEL")
         assert model is not None, "VLLM_MODEL env var must be set!"
         self._import(model)
-        with utils.MockServer(timeout=600) as _:
+        with utils.ScopedTritonServer(timeout=600):
             # vLLM will download the model on the fly, so give it a big timeout
             # TODO: Consider one of the following
             # (a) Pre-download and mount larger models in test environment
@@ -126,7 +126,7 @@ class TestE2E:
     def test_non_llm(self, protocol):
         # This test runs on the default Triton image, as well as on both TRT-LLM and VLLM images.
         # Use the existing models.
-        with utils.MockServer(repo=MODEL_REPO) as _:
+        with utils.ScopedTritonServer(repo=MODEL_REPO):
             model = "add_sub"
             # infer should work without a prompt for non-LLM models
             self._infer(model, protocol=protocol)
@@ -135,7 +135,7 @@ class TestE2E:
     def test_mock_llm(self, protocol):
         # This test runs on the default Triton image, as well as on both TRT-LLM and VLLM images.
         # Use the existing models.
-        with utils.MockServer(repo=MODEL_REPO) as _:
+        with utils.ScopedTritonServer(repo=MODEL_REPO):
             model = "mock_llm"
             # infer should work with a prompt for LLM models
             self._infer(model, prompt=PROMPT, protocol=protocol)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,7 +35,7 @@ from triton_cli.client.client import InferenceServerException
 
 
 class TritonCommands:
-    def run_and_capture_stdout(args):
+    def _run_and_capture_stdout(args):
         with io.StringIO() as buf, redirect_stdout(buf):
             run(args)
             return buf.getvalue()
@@ -78,21 +78,23 @@ class TritonCommands:
 
     def _metrics():
         args = ["metrics"]
-        output = TritonCommands.run_and_capture_stdout(args)
+        output = TritonCommands._run_and_capture_stdout(args)
         return json.loads(output)
 
     def _config(model):
         args = ["config", "-m", model]
-        output = TritonCommands.run_and_capture_stdout(args)
+        output = TritonCommands._run_and_capture_stdout(args)
         return json.loads(output)
 
     def _status(protocol="grpc"):
         args = ["status", "-i", protocol]
-        output = TritonCommands.run_and_capture_stdout(args)
+        output = TritonCommands._run_and_capture_stdout(args)
         return json.loads(output)
 
     def _clear(repo=None):
         args = ["remove", "-m", "all"]
+        if repo:
+            args += ["--repo", repo]
         run(args)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -97,10 +97,10 @@ class MockServer:
 
     def __enter__(self):
         self.pid = run_server(self.repo, self.mode)
-        wait_for_server_ready()
-        self._clear()
+        wait_for_server_ready()  # Polling
+        run(["remove", "-m", "all"])
 
-    def __exit__(self):
-        self._clear()
+    def __exit__(self, type, value, traceback):
+        run(["remove", "-m", "all"])
         kill_server(self.pid)
         self.repo, self.mode = None, None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -90,7 +90,7 @@ def check_server_ready(protocol="grpc"):
 
 
 # Context Manager to start and kill a mock server running in background and used by testing functions
-class MockServer:
+class ScopedTritonServer:
     def __init__(self, repo=None, mode="local", timeout=60):
         self.repo = repo
         self.mode = mode
@@ -99,7 +99,7 @@ class MockServer:
     def __enter__(self):
         run(["remove", "-m", "all"])
         self.pid = run_server(self.repo, self.mode)
-        wait_for_server_ready()  # Polling
+        wait_for_server_ready(timeout=self.timeout)  # Polling
 
     def __exit__(self, type, value, traceback):
         kill_server(self.pid)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,79 +29,132 @@ import psutil
 import io
 import json
 from contextlib import redirect_stdout
-from triton_cli.main import run
+from triton_cli.main import run, run_and_capture_stdout
 from subprocess import Popen
 from triton_cli.client.client import InferenceServerException
 
 
-def run_server(repo=None, mode="local"):
-    args = ["triton", "start"]
-    if repo:
-        args += ["--repo", repo]
-    if mode:
-        args += ["--mode", mode]
-    # Use Popen to run the server in the background as a separate process.
-    p = Popen(args)
-    return p.pid
-
-
-def wait_for_server_ready(timeout: int = 60):
-    start = time.time()
-    while time.time() - start < timeout:
-        print(
-            "Waiting for server to be ready ",
-            round(timeout - (time.time() - start)),
-            flush=True,
-        )
-        time.sleep(1)
-        try:
-            # For simplicity in testing, make sure both HTTP and GRPC endpoints
-            # are ready before marking server ready.
-            if check_server_ready(protocol="http") and check_server_ready(
-                protocol="grpc"
-            ):
-                return
-        except ConnectionRefusedError as e:
-            # Dump to log for testing transparency
-            print(e)
-        except InferenceServerException:
-            pass
-    raise Exception(f"=== Timeout {timeout} secs. Server not ready. ===")
-
-
-def kill_server(pid: int, sig: int = 2):
-    try:
-        proc = psutil.Process(pid)
-        proc.send_signal(sig)
-        proc.wait()
-    except psutil.NoSuchProcess as e:
-        print(e)
-
-
-def check_server_ready(protocol="grpc"):
-    args = ["status", "-i", protocol]
-    output = ""
-    # Redirect stdout to a buffer to capture the output of the command.
-    with io.StringIO() as buf, redirect_stdout(buf):
+class TritonCommands:
+    def _import(model, source=None, repo=None, backend=None):
+        args = ["import", "-m", model]
+        if source:
+            args += ["--source", source]
+        if repo:
+            args += ["--repo", repo]
+        if backend:
+            args += ["--backend", backend]
         run(args)
-        output = buf.getvalue()
-    output = json.loads(output)
-    return output["ready"]
+
+    def _remove(model, repo=None):
+        args = ["remove", "-m", model]
+        if repo:
+            args += ["--repo", repo]
+        run(args)
+
+    def _list(repo=None):
+        args = ["list"]
+        if repo:
+            args += ["--repo", repo]
+        run(args)
+
+    # Start Functionality is contained in ScopedTritonServer
+
+    def _infer(model, prompt=None, protocol=None):
+        args = ["infer", "-m", model]
+        if prompt:
+            args += ["--prompt", prompt]
+        if protocol:
+            args += ["-i", protocol]
+        run(args)
+
+    def _profile(model, backend):
+        args = ["profile", "-m", model, "--backend", backend]
+        run(args)
+
+    def _metrics():
+        args = ["metrics"]
+        output = run_and_capture_stdout(args)
+        return json.loads(output)
+
+    def _config(model):
+        args = ["config", "-m", model]
+        output = run_and_capture_stdout(args)
+        return json.loads(output)
+
+    def _status(protocol="grpc"):
+        args = ["status", "-i", protocol]
+        output = run_and_capture_stdout(args)
+        return json.loads(output)
+
+    def _clear(repo=None):
+        args = ["remove", "-m", "all"]
+        run(args)
 
 
-# Context Manager to start and kill a mock server running in background and used by testing functions
+# Context Manager to start and kill a server running in background and used by testing functions
 class ScopedTritonServer:
+    def run_server(self, repo=None, mode="local"):
+        args = ["triton", "start"]
+        if repo:
+            args += ["--repo", repo]
+        if mode:
+            args += ["--mode", mode]
+        # Use Popen to run the server in the background as a separate process.
+        p = Popen(args)
+        return p.pid
+
+    def wait_for_server_ready(self, timeout: int = 60):
+        start = time.time()
+        while time.time() - start < timeout:
+            print(
+                "Waiting for server to be ready ",
+                round(timeout - (time.time() - start)),
+                flush=True,
+            )
+            time.sleep(1)
+            try:
+                # For simplicity in testing, make sure both HTTP and GRPC endpoints
+                # are ready before marking server ready.
+                if self.check_server_ready(protocol="http") and self.check_server_ready(
+                    protocol="grpc"
+                ):
+                    return
+            except ConnectionRefusedError as e:
+                # Dump to log for testing transparency
+                print(e)
+            except InferenceServerException:
+                pass
+        raise Exception(f"=== Timeout {timeout} secs. Server not ready. ===")
+
+    def kill_server(self, pid: int, sig: int = 2):
+        try:
+            proc = psutil.Process(pid)
+            proc.send_signal(sig)
+            proc.wait()
+        except psutil.NoSuchProcess as e:
+            print(e)
+
+    def check_server_ready(self, protocol="grpc"):
+        args = ["status", "-i", protocol]
+        output = ""
+        # Redirect stdout to a buffer to capture the output of the command.
+        with io.StringIO() as buf, redirect_stdout(buf):
+            run(args)
+            output = buf.getvalue()
+        output = json.loads(output)
+        return output["ready"]
+
     def __init__(self, repo=None, mode="local", timeout=60):
         self.repo = repo
         self.mode = mode
         self.timeout = timeout
 
     def __enter__(self):
-        run(["remove", "-m", "all"])
-        self.pid = run_server(self.repo, self.mode)
-        wait_for_server_ready(timeout=self.timeout)  # Polling
+        self.pid = self.run_server(self.repo, self.mode)
+        # TritonCommands._clear()
+        self.wait_for_server_ready(timeout=self.timeout)  # Polling
 
     def __exit__(self, type, value, traceback):
-        kill_server(self.pid)
-        run(["remove", "-m", "all"])
+        self.kill_server(self.pid)
+        # TritonCommands._clear()
         self.repo, self.mode = None, None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -91,9 +91,10 @@ def check_server_ready(protocol="grpc"):
 
 # Context Manager to start and kill a mock server running in background and used by testing functions
 class MockServer:
-    def __init__(self, repo, mode="local"):
+    def __init__(self, repo=None, mode="local", timeout=60):
         self.repo = repo
         self.mode = mode
+        self.timeout = timeout
 
     def __enter__(self):
         run(["remove", "-m", "all"])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -96,11 +96,11 @@ class MockServer:
         self.mode = mode
 
     def __enter__(self):
+        run(["remove", "-m", "all"])
         self.pid = run_server(self.repo, self.mode)
         wait_for_server_ready()  # Polling
-        run(["remove", "-m", "all"])
 
     def __exit__(self, type, value, traceback):
-        run(["remove", "-m", "all"])
         kill_server(self.pid)
+        run(["remove", "-m", "all"])
         self.repo, self.mode = None, None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -94,8 +94,11 @@ class MockServer:
     def __init__(self):
         pass
 
-    def __enter__(self):
-        pass
+    def __enter__(self, repo, mode="local"):
+        self.pid = run_server(repo, mode)
+        wait_for_server_ready()
+        self._clear()
 
     def __exit__(self):
-        pass
+        self._clear()
+        kill_server(self.pid)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -91,14 +91,16 @@ def check_server_ready(protocol="grpc"):
 
 # Context Manager to start and kill a mock server running in background and used by testing functions
 class MockServer:
-    def __init__(self):
-        pass
+    def __init__(self, repo, mode="local"):
+        self.repo = repo
+        self.mode = mode
 
-    def __enter__(self, repo, mode="local"):
-        self.pid = run_server(repo, mode)
+    def __enter__(self):
+        self.pid = run_server(self.repo, self.mode)
         wait_for_server_ready()
         self._clear()
 
     def __exit__(self):
         self._clear()
         kill_server(self.pid)
+        self.repo, self.mode = None, None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -87,3 +87,15 @@ def check_server_ready(protocol="grpc"):
         output = buf.getvalue()
     output = json.loads(output)
     return output["ready"]
+
+
+# Context Manager to start and kill a mock server running in background and used by testing functions
+class MockServer:
+    def __init__(self):
+        pass
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self):
+        pass


### PR DESCRIPTION
This PR has been raised to address [Jira Ticket [DLIS-6803]](https://jirasw.nvidia.com/browse/DLIS-6803)

Replaces the existing (pytest.fixture and generator) approach with `ScopedTritonServer`, a context manager, that starts and kills the server. 

Specific features being added/addressed in this PR:
- Eliminates the need for pytest.fixture to kill the background server.
- Eliminates the need for generators to kill the background server. 
- Reduces the number of server-related arguments passed to the testing functions
- Context Manager (`ScopedTritonServer`) abstracts away process id logic from the test functions
- `ScopedTritonServer` Functions:
 - `__enter__()`: Sends start up command and polls until server is ready
 - `__exit__()`: Kills the server
