### PR TITLE
test: Shorten genai-perf test time, fail fast on server startup, and upgrade to 24.06

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -36,7 +36,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     container:
-      image: nvcr.io/nvidia/tritonserver:24.05-py3
+      image: nvcr.io/nvidia/tritonserver:24.06-py3
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -63,4 +63,4 @@ jobs:
       run: |
         python3 -m pip install pytest pytest-timeout pytest-cov psutil
         cd tests
-        pytest -vv --doctest-modules --junitxml=junit/test-results.xml --cov=triton_cli --cov-report=xml --cov-report=html --ignore-glob=test_models
+        pytest -s -vv --doctest-modules --junitxml=junit/test-results.xml --cov=triton_cli --cov-report=xml --cov-report=html --ignore-glob=test_models

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,18 +27,12 @@
 repos:
 
 # Python formatting/linting
-## Run the Ruff formatter.
+## Run the Ruff linter and formatter.
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.3
-  hooks:
-    - id: ruff-format
-      exclude: "src/triton_cli/trt_llm/checkpoint_scripts|src/triton_cli/templates/trt_llm"
-
-## Run the Ruff linter.
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.3
+  rev: v0.5.2
   hooks:
     - id: ruff
+    - id: ruff-format
       exclude: "src/triton_cli/trt_llm/checkpoint_scripts|src/triton_cli/templates/trt_llm"
 
 # Upgrade Python syntax

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,12 +27,18 @@
 repos:
 
 # Python formatting/linting
-## Run the Ruff linter and formatter.
+## Run the Ruff formatter.
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.5.2
+  hooks:
+    - id: ruff-format
+      exclude: "src/triton_cli/trt_llm/checkpoint_scripts|src/triton_cli/templates/trt_llm"
+
+## Run the Ruff linter.
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.5.2
   hooks:
     - id: ruff
-    - id: ruff-format
       exclude: "src/triton_cli/trt_llm/checkpoint_scripts|src/triton_cli/templates/trt_llm"
 
 # Upgrade Python syntax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,16 +50,16 @@ dependencies = [
     "grpcio>=1.64.0",
     "directory-tree == 0.0.4", # may remove in future
     "docker == 6.1.3",
-    "genai-perf @ git+https://github.com/triton-inference-server/client.git@r24.05#subdirectory=src/c++/perf_analyzer/genai-perf",
+    "genai-perf @ git+https://github.com/triton-inference-server/client.git@r24.06#subdirectory=src/c++/perf_analyzer/genai-perf",
     # TODO: rely on tritonclient to pull in protobuf and numpy dependencies?
     "numpy >=1.21,<2",
     "protobuf>=3.7.0",
     "prometheus-client == 0.19.0",
-    "psutil >= 5.9.5", # may remove later
+    "psutil < 6", # psutil 6.x may be causing some hangs
     "rich == 13.5.2",
     # TODO: Test on cpu-only machine if [cuda] dependency is an issue,
     # Use explicit client version matching genai-perf version for tagged release
-    "tritonclient[all] == 2.46",
+    "tritonclient[all] == 2.47",
     "huggingface-hub >= 0.19.4",
     # Testing
     "pytest >= 8.1.1", # may remove later

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "numpy >=1.21,<2",
     "protobuf>=3.7.0",
     "prometheus-client == 0.19.0",
-    "psutil < 6", # psutil 6.x may be causing some hangs
+    "psutil >= 5.9.5", # may remove later
     "rich == 13.5.2",
     # TODO: Test on cpu-only machine if [cuda] dependency is an issue,
     # Use explicit client version matching genai-perf version for tagged release

--- a/src/triton_cli/client/client.py
+++ b/src/triton_cli/client/client.py
@@ -256,7 +256,7 @@ class TritonClient:
         try:
             while completed_requests != num_requests:
                 result = user_data._completed_requests.get()
-                if type(result) == InferenceServerException:
+                if isinstance(result, InferenceServerException):
                     if result.status() == "StatusCode.CANCELLED":
                         is_final_response = True
                         logger.warning(

--- a/src/triton_cli/docker/Dockerfile
+++ b/src/triton_cli/docker/Dockerfile
@@ -1,5 +1,5 @@
 # TRT-LLM image contains engine building and runtime dependencies
-FROM nvcr.io/nvidia/tritonserver:24.05-trtllm-python-py3
+FROM nvcr.io/nvidia/tritonserver:24.06-trtllm-python-py3
 
 # Setup vLLM Triton backend
 RUN mkdir -p /opt/tritonserver/backends/vllm && \

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -115,5 +115,8 @@ class TestE2E:
             # infer should fail without a prompt for LLM models
             with pytest.raises(Exception):
                 TritonCommands._infer(model, protocol=protocol)
-            # profile should work without a prompt for LLM models
-            TritonCommands._profile(model, backend="tensorrtllm")
+
+            # profile for triton endpoints only supports grpc protocol currently
+            if protocol == "grpc":
+                # profile should work without a prompt for LLM models
+                TritonCommands._profile(model, backend="tensorrtllm")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -74,6 +74,9 @@ class TritonCommands:
 
     def _profile(model, backend):
         args = ["profile", "-m", model, "--backend", backend]
+        # NOTE: With default parameters, genai-perf may take upwards of 1m30s or 2m to run,
+        # so limit the genai-perf run with --request-count to reduce time for testing purposes.
+        args += ["--", "--request-count", "10"]
         run(args)
 
     def _metrics():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -178,11 +178,13 @@ class ScopedTritonServer:
                 pass
         raise Exception(f"=== Timeout {timeout} secs. Server not ready. ===")
 
-    def kill_server(self, pid: int, sig: int = 2):
+    def kill_server(self, pid: int, sig: int = 2, timeout: int = 30):
         try:
             proc = psutil.Process(pid)
             proc.send_signal(sig)
-            proc.wait()
+            # Add wait timeout to avoid hanging if process can't be cleanly
+            # stopped for some reason.
+            proc.wait(timeout=timeout)
         except psutil.NoSuchProcess as e:
             print(e)
 


### PR DESCRIPTION
This PR makes the following changes:
1. Adds `--request-count 10` to `genai-perf` when running `triton profile` in the test scripts. This is done to reduce risk of github action jobs timing out, use less overall github action minutes, and speed up local development time when running tests locally.

2. Removes the `triton profile` call for the `http` subtest, since `genai-perf` is using `grpc` under the hood for both tests, it was just wasting test time without adding value.

3. Improves the checks around server readiness to detect if the server process failed to start altogether, rather than waiting the full timeout period only polling the endpoints.

Note that locally, `--request-count 1` and `--request-count 10` both took about the same time of ~4-5 seconds instead of the previous default behavior taking 1m30s - 2m or so.

Overall, this should reduce the e2e test time by about 3-5 minutes in the succesful case, and possibly even more when server startups fail for some reason.

---

Example successful tests with genai-perf speedup changes, full test time is ~50seconds:

```
root@ced35d0-lcedt:/mnt/triton/cli/triton_cli/tests# pytest -v
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.10.12, pytest-8.2.2, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /mnt/triton/cli/triton_cli
configfile: pyproject.toml
plugins: timeout-2.3.1, mock-3.14.0
collected 55 items

test_cli.py::TestRepo::test_clear[None] PASSED                                                                                                                                          [  1%]
test_cli.py::TestRepo::test_clear[tmp/models] PASSED                                                                                                                                    [  3%]
test_cli.py::TestRepo::test_import_known_model[None-llama-2-7b] PASSED                                                                                                                  
...
test_cli.py::TestRepo::test_import_vllm[vllm-model-hf:gpt2] PASSED                                                                                                                      [ 63%]
test_cli.py::TestRepo::test_repo_add_trtllm_build[trtllm-model-hf:gpt2] SKIPPED (Only run for TRT-LLM image)                                                                            [ 65%]
test_cli.py::TestRepo::test_import_trtllm_prebuilt SKIPPED (Pre-built TRT-LLM engines not available)                                                                                    [ 67%]
test_cli.py::TestRepo::test_import_no_source PASSED                                                                                                                                     [ 69%]
test_cli.py::TestRepo::test_remove PASSED                                                                                                                                               [ 70%]
test_cli.py::TestRepo::test_remove_nonexistent PASSED                                                                                                                                   [ 72%]
test_cli.py::TestRepo::test_list[None] PASSED                                                                                                                                           [ 74%]
test_cli.py::TestRepo::test_list[tmp/models] PASSED                                                                                                                                     [ 76%]
test_cli.py::TestRepo::test_triton_profile PASSED                                                                                                                                       [ 78%]
test_cli.py::TestRepo::test_triton_metrics[mock_llm] PASSED                                                                                                                             [ 80%]
test_cli.py::TestRepo::test_triton_config[mock_llm] PASSED                                                                                                                              [ 81%]
test_cli.py::TestRepo::test_triton_status[mock_llm] PASSED                                                                                                                              [ 83%]
test_e2e.py::TestE2E::test_tensorrtllm_e2e[grpc] SKIPPED (Only run for TRT-LLM image)                                                                                                   [ 85%]
test_e2e.py::TestE2E::test_tensorrtllm_e2e[http] SKIPPED (Only run for TRT-LLM image)                                                                                                   [ 87%]
test_e2e.py::TestE2E::test_vllm_e2e[grpc] SKIPPED (Only run for VLLM image)                                                                                                             [ 89%]
test_e2e.py::TestE2E::test_vllm_e2e[http] SKIPPED (Only run for VLLM image)                                                                                                             [ 90%]
test_e2e.py::TestE2E::test_non_llm[grpc] PASSED                                                                                                                                         [ 92%]
test_e2e.py::TestE2E::test_non_llm[http] PASSED                                                                                                                                         [ 94%]
test_e2e.py::TestE2E::test_mock_llm[grpc] PASSED                                                                                                                                        [ 96%]
test_e2e.py::TestE2E::test_mock_llm[http] PASSED                                                                                                                                        [ 98%]
test_library.py::test_version PASSED                                                                                                                                                    [100%]

=============================================================================== 49 passed, 6 skipped in 50.46s ================================================================================
```

Example run with server startup failures, failing fast rather than waiting 60 seconds on each failed startup polling the endpoints:
```
================================================================================== short test summary info ===================================================================================
FAILED test_cli.py::TestRepo::test_triton_metrics[mock_llm] - Exception: 'triton start' PID 824213 was in a zombie state.
FAILED test_cli.py::TestRepo::test_triton_config[mock_llm] - Exception: 'triton start' PID 824227 was in a zombie state.
FAILED test_cli.py::TestRepo::test_triton_status[mock_llm] - Exception: 'triton start' PID 824242 was in a zombie state.
FAILED test_e2e.py::TestE2E::test_mock_llm[grpc] - Exception: 'triton start' PID 824254 was in a zombie state.
FAILED test_e2e.py::TestE2E::test_mock_llm[http] - Exception: 'triton start' PID 824266 was in a zombie state.
======================================================================== 5 failed, 50 deselected, 1 warning in 5.77s =========================================================================
```