### PR TITLE
Add Llama3.1-8B support for vLLM  and use KIND_MODEL for vLLM config by default

### DIFF
--- a/src/triton_cli/parser.py
+++ b/src/triton_cli/parser.py
@@ -60,6 +60,8 @@ KNOWN_MODEL_SOURCES = {
     "llama-2-7b-chat": "hf:meta-llama/Llama-2-7b-chat-hf",
     "llama-3-8b": "hf:meta-llama/Meta-Llama-3-8B",
     "llama-3-8b-instruct": "hf:meta-llama/Meta-Llama-3-8B-Instruct",
+    "llama-3.1-8b": "hf:meta-llama/Meta-Llama-3.1-8B",
+    "llama-3.1-8b-instruct": "hf:meta-llama/Meta-Llama-3.1-8B-Instruct",
     # Public
     "gpt2": "hf:gpt2",
     "opt125m": "hf:facebook/opt-125m",

--- a/src/triton_cli/repository.py
+++ b/src/triton_cli/repository.py
@@ -53,6 +53,7 @@ logger = logging.getLogger(LOGGER_NAME)
 # that can be fully autocompleted for a simple deployment.
 MODEL_CONFIG_TEMPLATE = """
 backend: "{backend}"
+instance_group {instance_group}
 """
 
 NGC_CONFIG_TEMPLATE = """
@@ -318,7 +319,10 @@ class ModelRepository:
 
     def __generate_vllm_model(self, huggingface_id: str):
         backend = "vllm"
-        model_config = MODEL_CONFIG_TEMPLATE.format(backend=backend)
+        instance_group = "[{kind: KIND_MODEL}]"
+        model_config = MODEL_CONFIG_TEMPLATE.format(
+            backend=backend, instance_group=instance_group
+        ).strip()
         model_contents = json.dumps(
             {
                 "model": huggingface_id,


### PR DESCRIPTION
Add Llama3.1-8B support for vLLM (not TRT-LLM yet), and use KIND_MODEL by default on vllm generated `config.pbtxt` for multi-gpu issues.

Note Llama3.1 support requires a higher vLLM version than what is currently in the 24.07 release. `pip install "vllm==0.5.3.post1"` in the 24.07 vLLM container worked though.