### PR TITLE
Iteratively deleting model directories when running `triton remove -m all`

### DIFF
--- a/src/triton_cli/repository.py
+++ b/src/triton_cli/repository.py
@@ -241,7 +241,11 @@ class ModelRepository:
 
     def clear(self):
         logger.info(f"Clearing all contents from {self.repo}...")
-        shutil.rmtree(self.repo)
+
+        # Loops through folders in self.repo (default: /root/models)
+        # and deletes each model directory individually.
+        for models in os.listdir(self.repo):
+            shutil.rmtree(self.repo / models)
 
     # No support for removing individual versions for now
     # TODO: remove doesn't support removing groups of models like TRT LLM at this time


### PR DESCRIPTION
Currently, when running through the [quickstart example](https://github.com/triton-inference-server/triton_cli/?tab=readme-ov-file#example), the `docker run ...` command to start the container, directly mounts `/root/models` to the host. 

So, when running `triton remove -m all`, the current workflow attempts to delete the entire folder `/root/models`, which results in the error `OSError: [Errno 16] Device or resource busy: '/root/models'`. 

This is because a folder that is directly mounted through docker cannot be deleted.

In order to remedy this, we can traverse through the model repository and delete the contents, without deleting the entire folder. 