### PR TITLE
fix: Add fix and test for 'triton' with no args

### DIFF
--- a/src/triton_cli/parser.py
+++ b/src/triton_cli/parser.py
@@ -444,9 +444,10 @@ def parse_args(argv=None):
 
     argv_ = argv if argv is not None else sys.argv[1:]
     # Add special argparse handling for passthrough to genai-perf CLI
-    if argv_[0] == "profile":
+    if len(argv_) > 1 and argv_[0] == "profile":
         args, unknown_args = parser.parse_known_args(argv_)
         args = add_unknown_args_to_args(args, unknown_args)
     else:
         args = parser.parse_args(argv_)
+
     return args

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,6 +49,15 @@ MODEL_REPO = os.path.join(TEST_DIR, "test_models")
 
 
 class TestRepo:
+    def test_noargs(self):
+        # Test that running 'triton' with no args will print help output
+        args = []
+        with pytest.raises(SystemExit) as excinfo:
+            TritonCommands._run_and_capture_stdout(args)
+
+        # argparse returns code 2 for error / missing arguments
+        assert excinfo.value.code == 2
+
     @pytest.mark.parametrize("repo", TEST_REPOS)
     def test_clear(self, repo):
         TritonCommands._clear(repo)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,7 +50,9 @@ MODEL_REPO = os.path.join(TEST_DIR, "test_models")
 
 class TestRepo:
     def test_noargs(self):
-        # Test that running 'triton' with no args will print help output
+        # Test that running 'triton' with no args will fail with a parsing error
+        # NOTE: pytest needs to be run with `--capture=sys` to read the output,
+        #       so just assert the error code and exception type for now.
         args = []
         with pytest.raises(SystemExit) as excinfo:
             TritonCommands._run_and_capture_stdout(args)


### PR DESCRIPTION
Before:
```
$ triton
triton - ERROR - list index out of range
triton - ERROR - Unexpected error:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/triton_cli/main.py", line 51, in main
    run()
  File "/usr/local/lib/python3.10/dist-packages/triton_cli/main.py", line 44, in run
    args = parser.parse_args(argv)
  File "/usr/local/lib/python3.10/dist-packages/triton_cli/parser.py", line 447, in parse_args
    if argv_[0] == "profile":
IndexError: list index out of range
```

After:
```
$ triton
usage: triton [-h] [-v] {import,remove,list,start,infer,profile,metrics,config,status} ...
triton: error: the following arguments are required: {import,remove,list,start,infer,profile,metrics,config,status}
```