### PR TITLE
fix: Upgrade docker==7.1.0 to fix incompatibilty with recent requests package versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ dependencies = [
     "genai-perf @ git+https://github.com/triton-inference-server/perf_analyzer.git@r24.10#subdirectory=genai-perf",
     # Misc deps
     "directory-tree == 0.0.4", # may remove in future
-    "docker == 6.1.3",
+    # https://github.com/docker/docker-py/issues/3256#issuecomment-2376439000
+    "docker == 7.1.0",
     # TODO: rely on tritonclient to pull in protobuf and numpy dependencies?
     "numpy >=1.21,<2",
     "protobuf>=3.7.0",


### PR DESCRIPTION
A recent version upgrade of the `requests` package had some breakage with the `docker` client package v0.6.x -- it's resolved by upgrading the docker client version to 7.1.0: https://github.com/docker/docker-py/issues/3256#issuecomment-2376439000

---

Before:
```
$ triton start --image nvcr.io/nvidia/tritonserver:24.10-vllm-python-py3
"Failed to start server in 'docker' mode. Error while fetching server API version: Not supported URL scheme http+docker"
```

After:
```
$ triton start --image nvcr.io/nvidia/tritonserver:24.10-vllm-python-py3
...
# OK
```

