### PR TITLE
build: add llmapi backend support, upgrade TRTLLM to 0.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,19 +307,23 @@ startup time.
 
 #### Example
 
+Please, make sure to replace <xx.yy> with the version of Triton that you want to use.
+The latest Triton Server container could be found [here](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver/tags).
 ```bash
-# This container comes with all of the dependencies for building TRT-LLM engines
-# and serving the engine with Triton Inference Server.
+TRITON_VERSION="<xx.yy>"
 docker run -ti \
   --gpus all \
   --network=host \
   --shm-size=1g --ulimit memlock=-1 \
   -v ${HOME}/models:/root/models \
   -v ${HOME}/.cache/huggingface:/root/.cache/huggingface \
-  nvcr.io/nvidia/tritonserver:25.0x-trtllm-python-py3
+  nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-trtllm-python-py3
 
 # Install the Triton CLI
-pip install git+https://github.com/triton-inference-server/triton_cli.git@0.1.3
+# Please, make sure to replace <x.y.z> with the version of Triton CLI, the version should be >= 0.1.3
+# The latest Triton CLI could be found in (https://github.com/triton-inference-server/triton_cli/releases)
+GIT_REF="<x.y.z>"
+pip install git+https://github.com/triton-inference-server/triton_cli.git@${GIT_REF}
 
 # Authenticate with huggingface for restricted models like Llama-2 and Llama-3
 huggingface-cli login

--- a/src/triton_cli/.gitignore
+++ b/src/triton_cli/.gitignore
@@ -1,2 +1,5 @@
 *.json
 *.cache
+
+# Except model.json from the llmapi template
+!templates/llmapi/1/model.json

--- a/src/triton_cli/repository.py
+++ b/src/triton_cli/repository.py
@@ -67,7 +67,9 @@ SOURCE_PREFIX_HUGGINGFACE = "hf:"
 SOURCE_PREFIX_NGC = "ngc:"
 SOURCE_PREFIX_LOCAL = "local:"
 
-TRT_TEMPLATES_PATH = Path(__file__).parent / "templates" / "trt_llm"
+TEMPLATES_PATH = Path(__file__).parent / "templates"
+TRT_TEMPLATES_PATH = TEMPLATES_PATH / "trt_llm"
+LLMAPI_TEMPLATES_PATH = TEMPLATES_PATH / "llmapi"
 
 # Support changing destination dynamically to point at
 # pre-downloaded checkpoints in various circumstances
@@ -190,7 +192,6 @@ class ModelRepository:
                 raise TritonCLIException(
                     f"Local file path '{model_path}' provided by --source does not exist"
                 )
-
         model_dir, version_dir = self.__create_model_repository(name, version, backend)
 
         # Note it's a bit redundant right now, but we check prefix above first
@@ -266,6 +267,8 @@ class ModelRepository:
                     self.remove(model, verbose=False)
                 # Let detailed traceback be reported for TRT-LLM errors for debugging
                 raise e
+        elif backend == "llmapi":
+            self.__generate_llmapi_model(version_dir, huggingface_id)
         else:
             # TODO: Add generic support for HuggingFace models with HF API.
             # For now, use vLLM as a means of deploying HuggingFace Transformers
@@ -305,6 +308,21 @@ class ModelRepository:
                 local_dir=hf_download_path,
                 use_auth_token=True,  # for gated repos like llama
             )
+
+    def __generate_llmapi_model(self, version_dir, huggingface_id: str):
+        # load the model.json from llmapi template
+        model_config_file = version_dir / "model.json"
+        with open(model_config_file) as f:
+            model_config_str = f.read()
+
+        model_config_json = json.loads(model_config_str)
+
+        # change the model id as the huggingface_id
+        model_config_json["model"] = huggingface_id
+
+        # write back the model.json
+        with open(model_config_file, "w") as f:
+            f.write(json.dumps(model_config_json))
 
     def __generate_vllm_model(self, huggingface_id: str):
         backend = "vllm"
@@ -402,6 +420,18 @@ class ModelRepository:
                 logger.debug(f"Adding TensorRT-LLM models at: {self.repo}")
             else:
                 version_dir.mkdir(parents=True, exist_ok=False)
+
+                if backend == "llmapi":
+                    shutil.copytree(
+                        LLMAPI_TEMPLATES_PATH / "1",
+                        version_dir,
+                        dirs_exist_ok=True,
+                        ignore=shutil.ignore_patterns("__pycache__"),
+                    )
+                    shutil.copy(
+                        LLMAPI_TEMPLATES_PATH / "config.pbtxt",
+                        model_dir,
+                    )
                 logger.debug(f"Adding new model to repo at: {version_dir}")
         except FileExistsError:
             logger.warning(f"Overwriting existing model in repo at: {version_dir}")

--- a/src/triton_cli/templates/llmapi/1/model.json
+++ b/src/triton_cli/templates/llmapi/1/model.json
@@ -1,0 +1,26 @@
+{
+    "max_batch_size": 64,
+    "decoupled": true,
+
+    "model":"placeholder",
+    "tokenizer": null,
+    "tokenizer_model": null,
+    "skip_tokenizer_init": null,
+    "trust_remote_code": null,
+    "tensor_parallel_size": null,
+    "dtype": null,
+    "revision": null,
+    "tokenizer_revision": null,
+    "speculative_model": null,
+    "enable_chunked_prefill": null,
+
+    "use_cuda_graph": null,
+    "cuda_graph_batch_sizes": null,
+    "cuda_graph_max_batch_size": null,
+    "cuda_graph_padding_enabled": null,
+    "enable_overlap_scheduler": null,
+    "kv_cache_dtype": null,
+    "torch_compile_enabled": null,
+    "torch_compile_fullgraph": null,
+    "torch_compile_inductor_enabled": null
+}

--- a/src/triton_cli/templates/llmapi/1/model.py
+++ b/src/triton_cli/templates/llmapi/1/model.py
@@ -1,0 +1,597 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import asyncio
+import gc
+import json
+import os
+import queue
+import threading
+from contextlib import asynccontextmanager
+
+import numpy as np
+import triton_python_backend_utils as pb_utils
+
+from tensorrt_llm import SamplingParams
+from tensorrt_llm._torch import LLM
+from tensorrt_llm._torch.pyexecutor.config import PyTorchConfig
+
+_TRTLLM_ENGINE_ARGS_FILENAME = "model.json"
+
+
+class TritonPythonModel:
+    # Define the expected keys for each config
+    # TODO: Add more keys as needed
+    PYTORCH_CONFIG_KEYS = {
+        "use_cuda_graph",
+        "cuda_graph_batch_sizes",
+        "cuda_graph_max_batch_size",
+        "cuda_graph_padding_enabled",
+        "enable_overlap_scheduler",
+        "kv_cache_dtype",
+        "torch_compile_enabled",
+        "torch_compile_fullgraph",
+        "torch_compile_inductor_enabled",
+    }
+
+    LLM_ENGINE_KEYS = {
+        "model",
+        "tokenizer",
+        "tokenizer_model",
+        "skip_tokenizer_init",
+        "trust_remote_code",
+        "tensor_parallel_size",
+        "dtype",
+        "revision",
+        "tokenizer_revision",
+        "speculative_model",
+        "enable_chunked_prefill",
+    }
+
+    def _get_input_scalar_by_name(self, request, name):
+        tensor = pb_utils.get_input_tensor_by_name(request, name)
+        if tensor is None:
+            return None
+
+        tensor = tensor.as_numpy()
+        if tensor.size == 0:
+            return None
+
+        return tensor.item(0)
+
+    def _get_sampling_config_from_request(self, request):
+        # TODO: Add more sampling parameters as needed
+        kwargs = {
+            "beam_width": self._get_input_scalar_by_name(request, "beam_width") or 1,
+            "temperature": self._get_input_scalar_by_name(request, "temperature"),
+            "top_k": self._get_input_scalar_by_name(request, "runtime_top_k"),
+            "top_p": self._get_input_scalar_by_name(request, "runtime_top_p"),
+        }
+
+        # Adjust top_p if it's not valid
+        kwargs["top_p"] = (
+            None if kwargs["top_p"] is None or kwargs["top_p"] <= 0 else kwargs["top_p"]
+        )
+
+        return kwargs
+
+    @classmethod
+    def auto_complete_config(cls, auto_complete_model_config):
+        # Add inputs/outputs to the model config.
+        cls._auto_complete_inputs_and_outputs(auto_complete_model_config)
+
+        # Get the max batch size and decoupled model transaction policy from the json file.
+        engine_args_filepath = os.path.join(
+            pb_utils.get_model_dir(), _TRTLLM_ENGINE_ARGS_FILENAME
+        )
+        assert os.path.isfile(
+            engine_args_filepath
+        ), f"'{_TRTLLM_ENGINE_ARGS_FILENAME}' containing TRT-LLM engine args must be provided in '{pb_utils.get_model_dir()}'"
+        with open(engine_args_filepath) as file:
+            # The Python interpreter used to invoke this function will be destroyed upon returning from this function and as a result none of the objects created here will be available in the initialize, execute, or finalize functions.
+            trtllm_engine_config = json.load(file)
+
+        model_config_keys = {"max_batch_size", "decoupled"}
+        auto_complete_config = {
+            k: v for k, v in trtllm_engine_config.items() if k in model_config_keys
+        }
+
+        # Set the max batch size and decoupled model transaction policy in the model config.
+        is_decoupled = auto_complete_config.get("decoupled", False)
+        auto_complete_model_config.set_model_transaction_policy(
+            dict(decoupled=is_decoupled)
+        )
+        max_batch_size = auto_complete_config.get("max_batch_size", 64)
+        auto_complete_model_config.set_max_batch_size(int(max_batch_size))
+
+        return auto_complete_model_config
+
+    @staticmethod
+    def _auto_complete_inputs_and_outputs(auto_complete_model_config):
+        # Inputs expected by the backend.
+        inputs = [
+            {"name": "text_input", "data_type": "TYPE_STRING", "dims": [1]},
+            {
+                "name": "stream",
+                "data_type": "TYPE_BOOL",
+                "dims": [1],
+                "optional": True,
+            },
+            {
+                "name": "exclude_input_in_output",
+                "data_type": "TYPE_BOOL",
+                "dims": [1],
+                "optional": True,
+            },
+            {
+                "name": "return_finish_reason",
+                "data_type": "TYPE_BOOL",
+                "dims": [1],
+                "optional": True,
+            },
+            {
+                "name": "return_stop_reason",
+                "data_type": "TYPE_BOOL",
+                "dims": [1],
+                "optional": True,
+            },
+            {
+                "name": "temperature",
+                "data_type": "TYPE_FP32",
+                "dims": [1],
+                "optional": True,
+            },
+            {
+                "name": "beam_width",
+                "data_type": "TYPE_INT32",
+                "dims": [1],
+                "optional": True,
+            },
+            {
+                "name": "runtime_top_k",
+                "data_type": "TYPE_INT32",
+                "dims": [1],
+                "optional": True,
+            },
+            {
+                "name": "runtime_top_p",
+                "data_type": "TYPE_FP32",
+                "dims": [1],
+                "optional": True,
+            },
+        ]
+        # Outputs expected by the backend.
+        outputs = [
+            {"name": "text_output", "data_type": "TYPE_STRING", "dims": [-1]},
+            {"name": "finish_reason", "data_type": "TYPE_STRING", "dims": [-1]},
+            {"name": "stop_reason", "data_type": "TYPE_STRING", "dims": [-1]},
+            {"name": "cumulative_logprob", "data_type": "TYPE_FP32", "dims": [-1]},
+        ]
+
+        # Collect input and output names from the provided model config.
+        config = auto_complete_model_config.as_dict()
+        input_names = []
+        output_names = []
+        for input in config["input"]:
+            input_names.append(input["name"])
+        for output in config["output"]:
+            output_names.append(output["name"])
+
+        # Add missing inputs and outputs to the model config.
+        for input in inputs:
+            if input["name"] not in input_names:
+                auto_complete_model_config.add_input(input)
+        for output in outputs:
+            if output["name"] not in output_names:
+                auto_complete_model_config.add_output(output)
+
+    def initialize(self, args):
+        self.model_config = json.loads(args["model_config"])
+        self.decoupled = pb_utils.using_decoupled_model_transaction_policy(
+            self.model_config
+        )
+        self.params = self.model_config["parameters"]
+        self.logger = pb_utils.Logger
+
+        output_config = pb_utils.get_output_config_by_name(
+            self.model_config, "text_output"
+        )
+        self.output_dtype = pb_utils.triton_string_to_numpy(output_config["data_type"])
+
+        # Initialize engine arguments
+        self._init_engine_args()
+
+        # Starting the TRT-LLM engine with LLM API and its event thread running the AsyncIO event loop.
+        self._init_engine()
+
+        # Starting the response thread. It allows TRT-LLM to keep making progress while
+        # response sender(s) are sending responses to server frontend.
+        self._response_queue = queue.Queue()
+        self._response_thread = threading.Thread(target=self._response_loop)
+        self._response_thread.start()
+
+    def _get_llm_args(self, args_dict):
+        pytorch_config_args = {
+            k: v
+            for k, v in args_dict.items()
+            if k in self.PYTORCH_CONFIG_KEYS and v is not None
+        }
+        llm_engine_args = {
+            k: v
+            for k, v in args_dict.items()
+            if k in self.LLM_ENGINE_KEYS and v is not None
+        }
+        if "model" not in llm_engine_args:
+            raise pb_utils.TritonModelException(
+                "Model name is required in the TRT-LLM engine config."
+            )
+
+        return pytorch_config_args, llm_engine_args
+
+    def _init_engine_args(self):
+        """Initialize engine arguments from config file."""
+        engine_args_filepath = os.path.join(
+            pb_utils.get_model_dir(), _TRTLLM_ENGINE_ARGS_FILENAME
+        )
+        if not os.path.isfile(engine_args_filepath):
+            raise pb_utils.TritonModelException(
+                f"'{_TRTLLM_ENGINE_ARGS_FILENAME}' containing TRT-LLM engine args must be provided in '{pb_utils.get_model_dir()}'"
+            )
+
+        try:
+            with open(engine_args_filepath) as file:
+                self.trtllm_engine_config = json.load(file)
+        except json.JSONDecodeError as e:
+            raise pb_utils.TritonModelException(f"Failed to parse engine config: {e}")
+
+        self.pytorch_config_args, self.llm_engine_args = self._get_llm_args(
+            self.trtllm_engine_config
+        )
+
+    def _init_engine(self):
+        # Run the engine in a separate thread running the AsyncIO event loop.
+        self._llm_engine = None
+        self._llm_engine_start_cv = threading.Condition()
+        self._llm_engine_shutdown_event = asyncio.Event()
+        self._event_thread = threading.Thread(
+            target=asyncio.run, args=(self._run_llm_engine(),)
+        )
+        self._event_thread.start()
+        with self._llm_engine_start_cv:
+            while self._llm_engine is None:
+                self._llm_engine_start_cv.wait()
+
+        # The 'threading.Thread()' will not raise the exception here should the engine
+        # failed to start, so the exception is passed back via the engine variable.
+        if isinstance(self._llm_engine, Exception):
+            e = self._llm_engine
+            self.logger.log_error(f"[trtllm] Failed to start engine: {e}")
+            if self._event_thread is not None:
+                self._event_thread.join()
+                self._event_thread = None
+            raise e
+
+    async def _run_llm_engine(self):
+        # Counter to keep track of ongoing request counts.
+        self._ongoing_request_count = 0
+
+        @asynccontextmanager
+        async def async_llm_wrapper():
+            # Create LLM in a thread to avoid blocking
+            loop = asyncio.get_running_loop()
+            try:
+                pytorch_config = PyTorchConfig(**self.pytorch_config_args)
+                llm = await loop.run_in_executor(
+                    None,
+                    lambda: LLM(
+                        **self.llm_engine_args, pytorch_backend_config=pytorch_config
+                    ),
+                )
+                yield llm
+            finally:
+                if "llm" in locals():
+                    # Run shutdown in a thread to avoid blocking
+                    await loop.run_in_executor(None, llm.shutdown)
+
+        try:
+            async with async_llm_wrapper() as engine:
+                # Capture the engine event loop and make it visible to other threads.
+                self._event_loop = asyncio.get_running_loop()
+
+                # Signal the engine is started and make it visible to other threads.
+                with self._llm_engine_start_cv:
+                    self._llm_engine = engine
+                    self._llm_engine_start_cv.notify_all()
+
+                # Wait for the engine shutdown signal.
+                await self._llm_engine_shutdown_event.wait()
+
+                # Wait for the ongoing requests to complete.
+                while self._ongoing_request_count > 0:
+                    self.logger.log_info(
+                        "[trtllm] Awaiting remaining {} requests".format(
+                            self._ongoing_request_count
+                        )
+                    )
+                    await asyncio.sleep(1)
+
+                # Cancel all tasks in the event loop.
+                for task in asyncio.all_tasks(loop=self._event_loop):
+                    if task is not asyncio.current_task():
+                        task.cancel()
+
+        except Exception as e:
+            # Signal and pass the exception back via the engine variable if the engine
+            # failed to start. If the engine has started, re-raise the exception.
+            with self._llm_engine_start_cv:
+                if self._llm_engine is None:
+                    self._llm_engine = e
+                    self._llm_engine_start_cv.notify_all()
+                    return
+            raise e
+
+        self._llm_engine = None
+        self.logger.log_info("[trtllm] Shutdown complete")
+
+    def _response_loop(self):
+        while True:
+            item = self._response_queue.get()
+            # To signal shutdown a None item will be added to the queue.
+            if item is None:
+                break
+            response_state, response, response_flag = item
+            response_sender = response_state["response_sender"]
+            try:
+                response_sender.send(response, response_flag)
+                # Stop checking for cancellation if the last response is generated.
+                if not response_state["last_response_generated"]:
+                    response_state["is_cancelled"] = response_sender.is_cancelled()
+            except Exception as e:
+                self.logger.log_error(
+                    f"An error occurred while sending a response: {e}"
+                )
+            finally:
+                if response_flag == pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL:
+                    self._ongoing_request_count -= 1
+
+    def execute(self, requests):
+        # TODO: Add health check here?
+        for request in requests:
+            # TODO : Verify Lora
+            if request is not None:
+                assert (
+                    self._llm_engine_shutdown_event.is_set() is False
+                ), "Cannot create tasks after shutdown has been requested"
+                coro = self._generate(request)
+                asyncio.run_coroutine_threadsafe(coro, self._event_loop)
+
+        return None
+
+    async def _generate(self, request):
+        response_sender = request.get_response_sender()
+        response_state = {
+            "response_sender": response_sender,
+            "is_cancelled": False,
+            "last_response_generated": False,  # last response ready but not yet sent
+        }
+        self._ongoing_request_count += 1
+        decrement_ongoing_request_count = True
+        try:
+            (
+                prompt,
+                stream,
+                prepend_input,
+                sampling_config,
+                additional_outputs,
+            ) = self._get_input_tensors(request)
+
+            sampling_params = SamplingParams(**sampling_config)
+
+            # Generate the response.
+            response_iterator = self._llm_engine.generate_async(
+                prompt, sampling_params, streaming=stream
+            )
+
+            request_output_state = {}
+            async for request_output in response_iterator:
+                # TODO: Add request cancellation check here
+                # Send each response if streaming.
+                if stream:
+                    response = self._create_response(
+                        request_output_state,
+                        request_output,
+                        prepend_input=False,
+                        additional_outputs=additional_outputs,
+                    )
+                    flags = 0
+                    if request_output.finished:
+                        response_state["last_response_generated"] = True
+                        flags = pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL
+                        decrement_ongoing_request_count = False
+                    self._response_queue.put_nowait((response_state, response, flags))
+
+            # Send the last response which contains all the outputs if not streaming.
+            if not stream:
+                response_sender.send(
+                    self._create_response(
+                        request_output_state={},
+                        request_output=request_output,
+                        prepend_input=prepend_input,
+                        additional_outputs=additional_outputs,
+                    ),
+                    flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL,
+                )
+
+        except Exception as e:
+            self.logger.log_error(f"[trtllm] Error generating stream: {e}")
+            error = pb_utils.TritonError(f"Error generating stream: {e}")
+            text_output_tensor = pb_utils.Tensor(
+                "text_output", np.asarray(["N/A"], dtype=self.output_dtype)
+            )
+            response = pb_utils.InferenceResponse(
+                output_tensors=[text_output_tensor], error=error
+            )
+            response_sender.send(
+                response, flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL
+            )
+            raise e
+
+        finally:
+            if decrement_ongoing_request_count:
+                self._ongoing_request_count -= 1
+
+    def _get_input_tensors(self, request):
+        # Parse the prompt based on the batch size.
+        text_input = pb_utils.get_input_tensor_by_name(request, "text_input").as_numpy()
+        prompt = (
+            text_input[0][0]
+            if self.model_config["max_batch_size"] > 0
+            else text_input[0]
+        )
+
+        if isinstance(prompt, bytes):
+            prompt = prompt.decode("utf-8")
+
+        # stream
+        stream = pb_utils.get_input_tensor_by_name(request, "stream")
+        if stream and not self.decoupled:
+            raise pb_utils.TritonModelException(
+                "Streaming is only supported in decoupled mode."
+            )
+        if stream:
+            stream = stream.as_numpy()[0]
+        else:
+            stream = False
+
+        # prepend_input / exclude_input_in_output
+        prepend_input = pb_utils.get_input_tensor_by_name(
+            request, "exclude_input_in_output"
+        )
+        if prepend_input:
+            # When `exclude_input_in_output` is False, we want to prepend input prompt
+            # to output, thus prepend_input should be True, and vice versa.
+            prepend_input = not prepend_input.as_numpy()[0]
+        elif prepend_input is None and stream:
+            prepend_input = False
+        else:
+            prepend_input = True
+        if prepend_input and stream:
+            raise pb_utils.TritonModelException(
+                "When streaming, `exclude_input_in_output` = False is not allowed."
+            )
+
+        # Sampling parameters
+        sampling_config = self._get_sampling_config_from_request(request)
+
+        # additional outputs
+        additional_outputs = {
+            "return_finish_reason": None,
+            "return_stop_reason": None,
+        }
+        for tensor_name in additional_outputs.keys():
+            tensor = pb_utils.get_input_tensor_by_name(request, tensor_name)
+            if tensor:
+                tensor = bool(tensor.as_numpy()[0])
+            else:
+                tensor = False
+            additional_outputs[tensor_name] = tensor
+
+        return prompt, stream, prepend_input, sampling_config, additional_outputs
+
+    def _create_response(
+        self, request_output_state, request_output, prepend_input, additional_outputs
+    ):
+        # TODO: Check if request_output has_error and handle it
+        output_tensors = []
+
+        # text_output
+        prepend_prompt = ""
+        if "prev_lens_text_output" not in request_output_state:
+            # this is the first response
+            if prepend_input:
+                prepend_prompt = request_output.prompt
+            request_output_state["prev_lens_text_output"] = [0] * len(
+                request_output.outputs
+            )
+        prev_lens = request_output_state["prev_lens_text_output"]
+        text_output = [
+            (prepend_prompt + output.text[prev_len:]).encode("utf-8")
+            for output, prev_len in zip(request_output.outputs, prev_lens)
+        ]
+        request_output_state["prev_lens_text_output"] = [
+            len(output.text) for output in request_output.outputs
+        ]
+
+        # finish_reason
+        if additional_outputs["return_finish_reason"]:
+            finish_reason = [
+                str(output.finish_reason) for output in request_output.outputs
+            ]
+            output_tensors.append(
+                pb_utils.Tensor(
+                    "finish_reason", np.asarray(finish_reason, dtype=np.object_)
+                )
+            )
+
+        # stop_reason
+        if additional_outputs["return_stop_reason"]:
+            stop_reason = [
+                str(output.finish_reason) for output in request_output.outputs
+            ]
+            output_tensors.append(
+                pb_utils.Tensor(
+                    "stop_reason", np.asarray(stop_reason, dtype=np.object_)
+                )
+            )
+
+        output_tensors.append(
+            pb_utils.Tensor(
+                "text_output", np.asarray(text_output, dtype=self.output_dtype)
+            )
+        )
+
+        return pb_utils.InferenceResponse(output_tensors=output_tensors)
+
+    def finalize(self):
+        self.logger.log_info("[trtllm] Issuing finalize to trtllm backend")
+        self._event_loop.call_soon_threadsafe(self._llm_engine_shutdown_event.set)
+
+        # Shutdown the event thread.
+        if self._event_thread is not None:
+            self._event_thread.join()
+            self._event_thread = None
+
+        # # Shutdown the response thread.
+        self._response_queue.put(None)
+        if self._response_thread is not None:
+            self._response_thread.join()
+            self._response_thread = None
+
+        # When using parallel tensors, the stub process may not shutdown due to
+        # unreleased references, so manually run the garbage collector once.
+        self.logger.log_info("[trtllm] Running Garbage Collector on finalize...")
+        gc.collect()
+        self.logger.log_info("[trtllm] Garbage Collector on finalize... done")

--- a/src/triton_cli/templates/llmapi/config.pbtxt
+++ b/src/triton_cli/templates/llmapi/config.pbtxt
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-# Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -25,27 +24,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+backend: "python"
 
-import os
-from pathlib import Path
-
-
-class TritonCLIException(Exception):
-    pass
-
-
-LOGGER_NAME: str = "triton"
-
-# Server
-DEFAULT_TRITONSERVER_PATH: str = "tritonserver"
-## Server Docker
-DEFAULT_SHM_SIZE: str = "1G"
-# A custom image containing both vLLM and TRT-LLM dependencies,
-# defined in triton_cli/docker/Dockerfile.
-DEFAULT_TRITONSERVER_IMAGE: str = "triton_llm"
-
-# Model Repository
-DEFAULT_MODEL_REPO: Path = Path.home() / "models"
-DEFAULT_HF_CACHE: Path = Path.home() / ".cache" / "huggingface"
-HF_CACHE: Path = Path(os.environ.get("HF_HOME", DEFAULT_HF_CACHE))
-SUPPORTED_BACKENDS: set = {"vllm", "tensorrtllm", "llmapi"}
+instance_group [
+  {
+    count: 1
+    kind : KIND_CPU
+  }
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,18 @@ def vllm_server():
 
 
 @pytest.fixture(scope="function")
+def llmapi_server():
+    llm_repo = None
+
+    # llmapi models might need to be downloaded on the fly during model loading,
+    # so leave longer timeout in case of slow network.
+    server = ScopedTritonServer(repo=llm_repo, timeout=1800)
+    yield server
+    # Ensure server is cleaned up after each test
+    server.stop()
+
+
+@pytest.fixture(scope="function")
 def simple_server():
     test_dir = os.path.dirname(os.path.realpath(__file__))
     simple_repo = os.path.join(test_dir, "test_models")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -37,6 +37,8 @@ TEST_REPOS = [None, os.path.join("tmp", "models")]
 CUSTOM_VLLM_MODEL_SOURCES = [("vllm-model", "hf:gpt2")]
 
 CUSTOM_TRTLLM_MODEL_SOURCES = [("trtllm-model", "hf:gpt2")]
+
+CUSTOM_LLMAPI_MODEL_SOURCES = [("llmapi-model", "hf:gpt2")]
 
 # TODO: Add public NGC model for testing
 CUSTOM_NGC_MODEL_SOURCES = [("my-llm", "ngc:does-not-exist")]
@@ -94,6 +96,16 @@ class TestRepo:
         # TODO: Parse repo to find TRT-LLM models and backend in config
         TritonCommands._clear()
         TritonCommands._import(model, source=source, backend="tensorrtllm")
+        TritonCommands._clear()
+
+    @pytest.mark.skipif(
+        os.environ.get("IMAGE_KIND") != "LLMAPI", reason="Only run for LLMAPI image"
+    )
+    @pytest.mark.parametrize("model,source", CUSTOM_TRTLLM_MODEL_SOURCES)
+    def test_repo_add_llmapi_build(self, model, source):
+        # TODO: Parse repo to find TRT-LLM models and backend in config
+        TritonCommands._clear()
+        TritonCommands._import(model, source=source, backend="llmapi")
         TritonCommands._clear()
 
     @pytest.mark.skip(reason="Pre-built TRT-LLM engines not available")

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -90,8 +90,11 @@ class TestE2E:
     )
     @pytest.mark.timeout(LLM_TIMEOUT_SECS)
     def test_llmapi_e2e(self, llmapi_server, protocol):
-        # NOTE: vLLM test models will be passed in by the testing infrastructure.
+        # NOTE: huggingface test models will be passed in by the testing infrastructure.
         # Only a single model will be passed in per test to enable tests to run concurrently.
+        # NOTE: llmapi "backend" is not using the exact same api format as tensorrtllm(tensorrt_llm_bls) backend or vllm backend,
+        # but genai-perf only supports those two. So we temporarily set genai-perf's backend as vllm,
+        # since the default request of vllm from genai-perf still work with llmapi "backend".
         model = os.environ.get("LLMAPI_MODEL")
         assert model is not None, "LLMAPI_MODEL env var must be set!"
         # Source is optional if using a "known: model"
@@ -100,9 +103,6 @@ class TestE2E:
         TritonCommands._import(model, source=source, backend="llmapi")
         llmapi_server.start()
         TritonCommands._infer(model, prompt=PROMPT, protocol=protocol)
-        # llmapi "backend" is not using the exact same api format as tensorrtllm(tensorrt_llm_bls) backend or vllm backend,
-        # but genai-perf only supports those two, temporarily set genai-perf's backend as vllm,
-        # since the default request of vllm from genai-perf still work with llmapi "backend"
         # TODO: update this to llmapi when genai-perf supports the llmapi backend's api format
         TritonCommands._profile(model, backend="vllm")
 


### PR DESCRIPTION
Adding the LLM API backend support in Triton CLI

The LLM API backend support is still under development: https://gitlab-master.nvidia.com/ftp/tekit_backend/-/merge_requests/1004

The files in the `src/triton_cli/templates/llmapi` are copied from the above MR.