### PR TITLE
feat: integrate openai frontend into triton cli

### DIFF
--- a/src/triton_cli/common.py
+++ b/src/triton_cli/common.py
@@ -38,11 +38,18 @@ LOGGER_NAME: str = "triton"
 
 # Server
 DEFAULT_TRITONSERVER_PATH: str = "tritonserver"
+DEFAULT_TRITONSERVER_OPENAI_FRONTEND_PATH: str = (
+    "/opt/tritonserver/python/openai/openai_frontend/main.py"
+)
+
 ## Server Docker
 DEFAULT_SHM_SIZE: str = "1G"
 # A custom image containing both vLLM and TRT-LLM dependencies,
 # defined in triton_cli/docker/Dockerfile.
 DEFAULT_TRITONSERVER_IMAGE: str = "triton_llm"
+
+# Serving Frontend
+SUPPORTED_FRONTEND: set = {"kserve", "openai"}
 
 # Model Repository
 DEFAULT_MODEL_REPO: Path = Path.home() / "models"

--- a/src/triton_cli/parser.py
+++ b/src/triton_cli/parser.py
@@ -40,6 +40,7 @@ from triton_cli.common import (
     DEFAULT_MODEL_REPO,
     DEFAULT_TRITONSERVER_IMAGE,
     LOGGER_NAME,
+    SUPPORTED_FRONTEND,
     TritonCLIException,
 )
 from triton_cli.client.client import InferenceServerException, TritonClient
@@ -155,6 +156,22 @@ def add_server_start_args(subcommands):
             required=False,
             default=300,
             help="Maximum number of seconds to wait for server startup. (Default: 300)",
+        )
+        subcommand.add_argument(
+            "--frontend",
+            choices=SUPPORTED_FRONTEND,
+            type=str,
+            required=False,
+            default="kserve",
+            help=f"The inference API frontend to use when starting the triton server. Default is the KServe api frontend. Choices: '{SUPPORTED_FRONTEND}'.",
+        )
+        subcommand.add_argument(
+            "--openai-chat-template-tokenizer",
+            type=str,
+            required=False,
+            # TODO: Should probably set a default tokenizer, like 'hf-internal-testing/llama-tokenizer', since not all tokenizers have a chat template
+            default=None,
+            help="HuggingFace ID or local folder path of the tokenizer to use for chat templates with the OpenAI API frontend. If no tokenizer is specified, it searches for and selects an LLM model's tokenizer from the model repository.",
         )
 
 

--- a/src/triton_cli/server/server_config.py
+++ b/src/triton_cli/server/server_config.py
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from triton_cli.common import (
+    DEFAULT_TRITONSERVER_PATH,
+    DEFAULT_TRITONSERVER_OPENAI_FRONTEND_PATH,
+)
+
 
 class TritonServerConfig:
     """
@@ -73,12 +78,19 @@ class TritonServerConfig:
         "tensorflow-version",
     ]
 
-    def __init__(self):
+    def __init__(self, server_path=None):
         """
         Construct TritonServerConfig
+
+        Parameters
+        ----------
+        server_path: string
+            path to the triton server binary. Default is "tritonserver" if unset.
         """
 
         self._server_args = {k: None for k in self.server_arg_keys}
+        self._server_path = server_path if server_path else DEFAULT_TRITONSERVER_PATH
+        self._server_name = "Triton Inference Server"
 
     @classmethod
     def allowed_keys(cls):
@@ -172,6 +184,16 @@ class TritonServerConfig:
 
         return self._server_args
 
+    def server_path(self):
+        """
+        Returns
+        -------
+        Path
+            A path to the triton server binary or script
+        """
+
+        return self._server_path
+
     # TODO: Investigate what parameters are supported with TRT LLM's launching style.
     # For example, explicit launch mode is not. See the TRTLLMUtils class for a list of
     # supported args.
@@ -231,6 +253,45 @@ class TritonServerConfig:
             self._server_args[kebab_cased_key] = value
         else:
             raise Exception(
-                f"The argument '{key}' to the Triton Inference "
-                "Server is not currently supported."
+                f"The argument '{key}' to the {self._server_name}"
+                " is not currently supported."
             )
+
+
+class TritonOpenAIServerConfig(TritonServerConfig):
+    """
+    A config class to set arguments to the Triton Inference
+    Server with OpenAI RESTful API. An argument set to None will use the server default.
+    """
+
+    server_arg_keys = [
+        # triton server args
+        "tritonserver-log-verbose-level",
+        "host",
+        "backend",
+        "tokenizer",
+        "model-repository",
+        # uvicorn args
+        "openai-port",
+        "uvicorn-log-level",
+        # kserve frontend args
+        "enable-kserve-frontends",
+        "kserve-http-port",
+        "kserve-grpc-port",
+    ]
+
+    def __init__(self, server_path=None):
+        """
+        Construct TritonOpenAIServerConfig
+
+        Parameters
+        ----------
+        server_path: string
+            path to the Triton OpenAI Server python script. Default is "/opt/tritonserver/python/openai/openai_frontend/main.py" if unset.
+        """
+
+        self._server_args = {k: None for k in self.server_arg_keys}
+        self._server_path = (
+            server_path if server_path else DEFAULT_TRITONSERVER_OPENAI_FRONTEND_PATH
+        )
+        self._server_name = "Triton Inference Server with OpenAI RESTful API"

--- a/src/triton_cli/server/server_config.py
+++ b/src/triton_cli/server/server_config.py
@@ -184,11 +184,11 @@ class TritonServerConfig:
 
         return self._server_args
 
-    def server_path(self):
+    def server_path(self) -> str:
         """
         Returns
         -------
-        Path
+        str
             A path to the triton server binary or script
         """
 

--- a/src/triton_cli/server/server_docker.py
+++ b/src/triton_cli/server/server_docker.py
@@ -23,7 +23,6 @@ from .server import TritonServer
 from .server_utils import TritonServerUtils
 from triton_cli.common import (
     HF_CACHE,
-    DEFAULT_TRITONSERVER_PATH,
     DEFAULT_TRITONSERVER_IMAGE,
     LOGGER_NAME,
 )
@@ -164,7 +163,6 @@ class TritonServerDocker(TritonServer):
         }
         # Construct run command
         command = self._server_utils.get_launch_command(
-            tritonserver_path=DEFAULT_TRITONSERVER_PATH,
             server_config=self._server_config,
             cmd_as_list=False,
             env_cmds=env_cmds,

--- a/src/triton_cli/server/server_factory.py
+++ b/src/triton_cli/server/server_factory.py
@@ -15,19 +15,17 @@
 # limitations under the License.
 
 import logging
-import os
 import shutil
 
 from .server_local import TritonServerLocal
 from .server_docker import TritonServerDocker
-from .server_config import TritonServerConfig
+from .server_config import TritonServerConfig, TritonOpenAIServerConfig
 from triton_cli.common import (
     DEFAULT_SHM_SIZE,
-    DEFAULT_TRITONSERVER_PATH,
     LOGGER_NAME,
     TritonCLIException,
 )
-
+from .server_utils import TRTLLMUtils, VLLMUtils
 
 logger = logging.getLogger(LOGGER_NAME)
 
@@ -82,7 +80,7 @@ class TritonServerFactory:
         )
 
     @staticmethod
-    def create_server_local(path, config, gpus=None):
+    def create_server_local(config, gpus=None):
         """
         Parameters
         ----------
@@ -99,7 +97,7 @@ class TritonServerFactory:
         TritonServerLocal
         """
 
-        return TritonServerLocal(path=path, config=config, gpus=gpus)
+        return TritonServerLocal(config=config, gpus=gpus)
 
     @staticmethod
     def get_server_handle(config, gpus=None):
@@ -130,15 +128,10 @@ class TritonServerFactory:
 
     @staticmethod
     def _get_local_server_handle(config, gpus):
-        tritonserver_path = DEFAULT_TRITONSERVER_PATH
-        TritonServerFactory._validate_triton_server_path(tritonserver_path)
+        triton_config = TritonServerFactory._get_triton_server_config(config)
+        TritonServerFactory._validate_triton_server_path(triton_config.server_path())
 
-        triton_config = TritonServerConfig()
-        triton_config["model-repository"] = config.model_repository
-        if config.verbose:
-            triton_config["log-verbose"] = "1"
         server = TritonServerFactory.create_server_local(
-            path=tritonserver_path,
             config=triton_config,
             gpus=gpus,
         )
@@ -147,10 +140,7 @@ class TritonServerFactory:
 
     @staticmethod
     def _get_docker_server_handle(config, gpus):
-        triton_config = TritonServerConfig()
-        triton_config["model-repository"] = os.path.abspath(config.model_repository)
-        if config.verbose:
-            triton_config["log-verbose"] = "1"
+        triton_config = TritonServerFactory._get_triton_server_config(config)
 
         server = TritonServerFactory.create_server_docker(
             image=config.image,
@@ -174,3 +164,39 @@ class TritonServerFactory:
             raise TritonCLIException(
                 f"Either the binary {tritonserver_path} is invalid, not on the PATH, or does not have the correct permissions."
             )
+
+    @staticmethod
+    def _get_triton_server_config(config):
+        """
+        Raises an exception if a tokenizer can not be found and is not specified with OpenAI Frontend
+        """
+        if config.frontend == "openai":
+            triton_config = TritonOpenAIServerConfig()
+            triton_config["model-repository"] = config.model_repository
+
+            if config.openai_chat_template_tokenizer is None:
+                trtllm_utils = TRTLLMUtils(triton_config["model-repository"])
+                vllm_utils = VLLMUtils(triton_config["model-repository"])
+
+                if trtllm_utils.has_trtllm_model():
+                    triton_config["tokenizer"] = trtllm_utils.get_engine_path()
+                elif vllm_utils.has_vllm_model():
+                    triton_config["tokenizer"] = (
+                        vllm_utils.get_vllm_model_huggingface_id_or_path()
+                    )
+                else:
+                    raise TritonCLIException(
+                        "Unable to find a tokenizer to start the Triton OpenAI RESTful API, please use '--openai-chat-template-tokenizer' to specify a tokenizer."
+                    )
+            else:
+                triton_config["tokenizer"] = config.openai_chat_template_tokenizer
+
+            if config.verbose:
+                triton_config["tritonserver-log-verbose-level"] = "1"
+        else:
+            triton_config = TritonServerConfig()
+            triton_config["model-repository"] = config.model_repository
+            if config.verbose:
+                triton_config["log-verbose"] = "1"
+
+        return triton_config

--- a/src/triton_cli/server/server_local.py
+++ b/src/triton_cli/server/server_local.py
@@ -34,21 +34,18 @@ class TritonServerLocal(TritonServer):
     tritonserver locally as as subprocess.
     """
 
-    def __init__(self, path, config, gpus):
+    def __init__(self, config, gpus):
         """
         Parameters
         ----------
-        path  : str
-            The absolute path to the tritonserver executable
         config : TritonServerConfig
-            the config object containing arguments for this server instance
+            the config object containing arguments and path for this server instance
         gpus: list of str
             List of GPU UUIDs to be made visible to Triton
         """
 
         self._tritonserver_process = None
         self._server_config = config
-        self._server_path = path
         self._gpus = gpus
         self._is_first_time_starting_server = True
 
@@ -84,47 +81,45 @@ class TritonServerLocal(TritonServer):
             f"Starting a Triton Server locally with model repository: {self._server_config['model-repository']}"
         )
 
-        if self._server_path:
-            # Get the appropriate server launch command
-            cmd = self._server_utils.get_launch_command(
-                tritonserver_path=self._server_path,
-                server_config=self._server_config,
-                cmd_as_list=True,
+        # Get the appropriate server launch command
+        cmd = self._server_utils.get_launch_command(
+            server_config=self._server_config,
+            cmd_as_list=True,
+        )
+
+        # Set environment, update with user config env
+        triton_env = os.environ.copy()
+
+        if env:
+            # Filter env variables that use env lookups
+            for variable, value in env.items():
+                if value.find("$") == -1:
+                    triton_env[variable] = value
+                else:
+                    # Collect the ones that need lookups to give to the shell
+                    triton_env[variable] = os.path.expandvars(value)
+
+        # List GPUs to be used by tritonserver
+        if self._gpus:
+            raise Exception(
+                "GPUs aren't configurable at this time, leave it unspecified."
             )
 
-            # Set environment, update with user config env
-            triton_env = os.environ.copy()
+        self._is_first_time_starting_server = False
 
-            if env:
-                # Filter env variables that use env lookups
-                for variable, value in env.items():
-                    if value.find("$") == -1:
-                        triton_env[variable] = value
-                    else:
-                        # Collect the ones that need lookups to give to the shell
-                        triton_env[variable] = os.path.expandvars(value)
-
-            # List GPUs to be used by tritonserver
-            if self._gpus:
-                raise Exception(
-                    "GPUs aren't configurable at this time, leave it unspecified."
-                )
-
-            self._is_first_time_starting_server = False
-
-            # Construct Popen command
-            try:
-                self._tritonserver_process = Popen(
-                    cmd,
-                    stdout=PIPE,
-                    stderr=STDOUT,
-                    start_new_session=True,
-                    universal_newlines=True,
-                    env=triton_env,
-                )
-            except Exception as e:
-                logger.error(e)
-                raise Exception(e)
+        # Construct Popen command
+        try:
+            self._tritonserver_process = Popen(
+                cmd,
+                stdout=PIPE,
+                stderr=STDOUT,
+                start_new_session=True,
+                universal_newlines=True,
+                env=triton_env,
+            )
+        except Exception as e:
+            logger.error(e)
+            raise Exception(e)
 
     def stop(self):
         """

--- a/src/triton_cli/server/server_utils.py
+++ b/src/triton_cli/server/server_utils.py
@@ -232,7 +232,7 @@ class TRTLLMUtils:
 
 class VLLMUtils:
     """
-    A utility class for handling TRT LLM-specific models.
+    A utility class for handling vLLM specific models.
     """
 
     def __init__(self, model_path: str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,35 @@ def vllm_server():
 
 
 @pytest.fixture(scope="function")
+def trtllm_openai_server():
+    llm_repo = None
+
+    # TRT-LLM models should be pre-built offline, and only need to be read
+    # from disk at server startup time, so they should generally load faster
+    # than vLLM models, but still give some room for long startup.
+    server = ScopedTritonServer(repo=llm_repo, timeout=600, frontend="openai")
+    yield server
+    # Ensure server is cleaned up after each test
+    server.stop()
+
+
+@pytest.fixture(scope="function")
+def vllm_openai_server():
+    llm_repo = None
+
+    # vLLM models are downloaded on the fly during model loading as part of
+    # server startup, so give even more room for timeout in case of slow network
+    #     TODO: Consider one of the following
+    #     (a) Pre-download and mount larger models in test environment
+    #     (b) Download model from HF for vLLM at import step to remove burden
+    #         from server startup step.
+    server = ScopedTritonServer(repo=llm_repo, timeout=1800, frontend="openai")
+    yield server
+    # Ensure server is cleaned up after each test
+    server.stop()
+
+
+@pytest.fixture(scope="function")
 def simple_server():
     test_dir = os.path.dirname(os.path.realpath(__file__))
     simple_repo = os.path.join(test_dir, "test_models")

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -72,6 +72,28 @@ class TestE2E:
         TritonCommands._profile(model, backend="tensorrtllm")
 
     @pytest.mark.skipif(
+        os.environ.get("IMAGE_KIND") != "TRTLLM", reason="Only run for TRT-LLM image"
+    )
+    @pytest.mark.skipif(
+        os.environ.get("TRTLLM_MODEL") == "gpt2",
+        reason="gpt2's tokenizer doesn't have a chat template defined",
+    )
+    @pytest.mark.timeout(LLM_TIMEOUT_SECS)
+    def test_tensorrtllm_openai_e2e(self, trtllm_openai_server):
+        # NOTE: TRTLLM test models will be passed by the testing infrastructure.
+        # Only a single model will be passed per test to enable tests to run concurrently.
+        model = os.environ.get("TRTLLM_MODEL")
+        assert model is not None, "TRTLLM_MODEL env var must be set!"
+        # Source is optional if using a "known: model"
+        source = os.environ.get("MODEL_SOURCE")
+        TritonCommands._clear()
+        TritonCommands._import(model, source=source, backend="tensorrtllm")
+        trtllm_openai_server.start()
+        TritonCommands._profile(
+            model, service_kind="openai", endpoint_type="chat", url="localhost:9000"
+        )
+
+    @pytest.mark.skipif(
         os.environ.get("IMAGE_KIND") != "VLLM", reason="Only run for VLLM image"
     )
     @pytest.mark.parametrize(
@@ -100,6 +122,28 @@ class TestE2E:
         vllm_server.start()
         TritonCommands._infer(model, prompt=PROMPT, protocol=protocol)
         TritonCommands._profile(model, backend="vllm")
+
+    @pytest.mark.skipif(
+        os.environ.get("IMAGE_KIND") != "VLLM", reason="Only run for VLLM image"
+    )
+    @pytest.mark.skipif(
+        os.environ.get("VLLM_MODEL") == "gpt2",
+        reason="gpt2's tokenizer doesn't have a chat template defined",
+    )
+    @pytest.mark.timeout(LLM_TIMEOUT_SECS)
+    def test_vllm_openai_e2e(self, vllm_openai_server):
+        # NOTE: VLLM test models will be passed by the testing infrastructure.
+        # Only a single model will be passed per test to enable tests to run concurrently.
+        model = os.environ.get("VLLM_MODEL")
+        assert model is not None, "VLLM_MODEL env var must be set!"
+        # Source is optional if using a "known: model"
+        source = os.environ.get("MODEL_SOURCE")
+        TritonCommands._clear()
+        TritonCommands._import(model, source=source)
+        vllm_openai_server.start()
+        TritonCommands._profile(
+            model, service_kind="openai", endpoint_type="chat", url="localhost:9000"
+        )
 
     @pytest.mark.skipif(
         os.environ.get("CI_PIPELINE") == "GITHUB_ACTIONS",


### PR DESCRIPTION
This PR is for fixing the CI not triggered issue in
https://github.com/triton-inference-server/triton_cli/pull/106

The branch that I was created for the PR has squashed commits and is not being synced to the gitlab to trigger the CI.
So I recreated another branch for triggering the gitlab CI.

1. adding a --frontend openai command line argument to the start command.
An Triton Server with openai frontend can be start with triron start --frontend openai

2. adding a --openai-chat-template-tokenizer <model_name> command line arguments to help specify the chat template tokenizer. If this is not being specified, triton cli will find one from the model repository.