### PR TITLE
Fix local source prefix bug

### DIFF
--- a/src/triton_cli/repository.py
+++ b/src/triton_cli/repository.py
@@ -185,7 +185,7 @@ class ModelRepository:
                 )
 
             source_type = "local"
-            model_path = Path(source)
+            model_path = Path(source.replace(SOURCE_PREFIX_LOCAL, ""))
             if not model_path.exists():
                 raise TritonCLIException(
                     f"Local file path '{model_path}' provided by --source does not exist"

--- a/src/triton_cli/repository.py
+++ b/src/triton_cli/repository.py
@@ -212,8 +212,15 @@ class ModelRepository:
             #       point to downloaded engines, etc.
             self.__generate_ngc_model(name, ngc_model_name)
         else:
-            logger.debug(f"Copying {model_path} to {version_dir}")
-            shutil.copy(model_path, version_dir)
+            if model_path.is_dir():
+                logger.debug(f"Copying directory {model_path} to {version_dir}")
+                # If version_dir already exists, remove it first
+                if version_dir.exists():
+                    shutil.rmtree(version_dir)
+                shutil.copytree(model_path, version_dir)
+            else:
+                logger.debug(f"Copying file {model_path} to {version_dir}")
+                shutil.copy(model_path, version_dir)
 
         if verbose:
             self.list()

--- a/src/triton_cli/repository.py
+++ b/src/triton_cli/repository.py
@@ -213,13 +213,13 @@ class ModelRepository:
             self.__generate_ngc_model(name, ngc_model_name)
         else:
             if model_path.is_dir():
-                logger.debug(f"Copying directory {model_path} to {version_dir}")
+                logger.info(f"Copying model directory {model_path} to {version_dir}")
                 # If version_dir already exists, remove it first
                 if version_dir.exists():
                     shutil.rmtree(version_dir)
                 shutil.copytree(model_path, version_dir)
             else:
-                logger.debug(f"Copying file {model_path} to {version_dir}")
+                logger.info(f"Copying model file {model_path} to {version_dir}")
                 shutil.copy(model_path, version_dir)
 
         if verbose:


### PR DESCRIPTION
Getting this error when using --source <path>:

`triton - ERROR - Local file path 'local:/workspace/engines/llama-2-7b' provided by --source does not exist`

This is due to a bug in repository.py where the source is not stripped of the SOURCE_PREFIX_LOCAL before doing Path(source). 

Also, the copy assumes a file, but the model is a directory, so adding code to copy the directory and also printing a message while waiting for the copy.