### PR TITLE
bug: fixing start docker command, fixing openai port expose, fixing dockerfile

### DIFF
--- a/src/triton_cli/docker/Dockerfile
+++ b/src/triton_cli/docker/Dockerfile
@@ -34,4 +34,4 @@ RUN mkdir -p /opt/tritonserver/backends/vllm && \
     rm -r /tmp/vllm_backend
 
 # vLLM runtime dependencies
-RUN pip install "vllm==0.6.3.post1" "setuptools==74.0.0"
+RUN pip install "vllm==0.6.3.post1" "setuptools>=74.1.1"

--- a/src/triton_cli/server/server_docker.py
+++ b/src/triton_cli/server/server_docker.py
@@ -133,13 +133,13 @@ class TritonServerDocker(TritonServer):
         # Mount required directories
         volumes = {}
         # Mount model repository at same path in read-only mode for simplicity
-        volumes[self._server_config["model-repository"]] = {
-            "bind": self._server_config["model-repository"],
+        volumes[str(self._server_config["model-repository"])] = {
+            "bind": str(self._server_config["model-repository"]),
             "mode": "ro",
         }
         # Mount huggingface model cache to save time across runs
         # Use default cache in container for now.
-        volumes[HF_CACHE] = {
+        volumes[str(HF_CACHE)] = {
             "bind": "/root/.cache/huggingface",
             "mode": "rw",
         }
@@ -155,11 +155,13 @@ class TritonServerDocker(TritonServer):
         server_http_port = 8000
         server_grpc_port = 8001
         server_metrics_port = 8002
+        openai_http_port = 9000
 
         ports = {
             server_http_port: server_http_port,
             server_grpc_port: server_grpc_port,
             server_metrics_port: server_metrics_port,
+            openai_http_port: openai_http_port,
         }
         # Construct run command
         command = self._server_utils.get_launch_command(


### PR DESCRIPTION
1. Fix the `triton start` command to start docker with volumns, it can only accept string type rather than Path
2. Fix the openai port exposing, adding 9000 to the docker container
3. fix the dockerfile  `pip install`