### PR TITLE
Fix: Checking local model path

### DIFF
--- a/src/triton_cli/repository.py
+++ b/src/triton_cli/repository.py
@@ -185,7 +185,7 @@ class ModelRepository:
                 )
 
             source_type = "local"
-            model_path = Path(source)
+            model_path = Path(source.replace(SOURCE_PREFIX_LOCAL,""))
             if not model_path.exists():
                 raise TritonCLIException(
                     f"Local file path '{model_path}' provided by --source does not exist"


### PR DESCRIPTION
Current version looks for a path appended with the "local:" prefix, resulting in the error:  triton - ERROR - Local file path 'local:<file_path>'