### PR TITLE
ci: Fix `L0_triton_cli_test_vllm--base`

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ curl -s http://localhost:9000/v1/chat/completions -H 'Content-Type: application/
 }'
 
 # Profile model with GenAI-Perf
-triton profile -m llama-3.1-8b-instruct --service-kind openai --endpoint-type chat --url localhost:9000 --streaming
+triton profile -m llama-3.1-8b-instruct --endpoint-type chat --url localhost:9000 --streaming
 ```
 
 ## Additional Dependencies for Custom Environments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "grpcio>=1.67.0",
     # Use explicit client version matching genai-perf version for tagged release
     "tritonclient[all] == 2.55.0",
-    "genai-perf @ git+https://github.com/triton-inference-server/perf_analyzer.git@r25.10#subdirectory=genai-perf",
+    "genai-perf @ git+https://github.com/triton-inference-server/perf_analyzer.git@main#subdirectory=genai-perf",
     # Misc deps
     "directory-tree == 0.0.4", # may remove in future
     # https://github.com/docker/docker-py/issues/3256#issuecomment-2376439000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,10 @@ requires-python = ">=3.10,<4"
 dependencies = [
     # Client deps - generally versioned together
     "grpcio>=1.67.0",
+    # "openai==1.107.3",  # Pin OpenAI SDK to match vLLM requirements
     # Use explicit client version matching genai-perf version for tagged release
     "tritonclient[all] == 2.55.0",
-    "genai-perf @ git+https://github.com/triton-inference-server/perf_analyzer.git@r25.02#subdirectory=genai-perf",
+    "genai-perf @ git+https://github.com/triton-inference-server/perf_analyzer.git@r25.10#subdirectory=genai-perf",
     # Misc deps
     "directory-tree == 0.0.4", # may remove in future
     # https://github.com/docker/docker-py/issues/3256#issuecomment-2376439000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ requires-python = ">=3.10,<4"
 dependencies = [
     # Client deps - generally versioned together
     "grpcio>=1.67.0",
-    # "openai==1.107.3",  # Pin OpenAI SDK to match vLLM requirements
     # Use explicit client version matching genai-perf version for tagged release
     "tritonclient[all] == 2.55.0",
     "genai-perf @ git+https://github.com/triton-inference-server/perf_analyzer.git@r25.10#subdirectory=genai-perf",

--- a/src/triton_cli/repository.py
+++ b/src/triton_cli/repository.py
@@ -315,7 +315,6 @@ class ModelRepository:
         model_contents = json.dumps(
             {
                 "model": huggingface_id,
-                "disable_log_requests": True,
                 "gpu_memory_utilization": 0.85,
             }
         )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -89,9 +89,7 @@ class TestE2E:
         TritonCommands._clear()
         TritonCommands._import(model, source=source, backend="tensorrtllm")
         trtllm_openai_server.start()
-        TritonCommands._profile(
-            model, service_kind="openai", endpoint_type="chat", url="localhost:9000"
-        )
+        TritonCommands._profile(model, endpoint_type="chat", url="localhost:9000")
 
     @pytest.mark.skipif(
         os.environ.get("IMAGE_KIND") != "VLLM", reason="Only run for VLLM image"
@@ -141,9 +139,7 @@ class TestE2E:
         TritonCommands._clear()
         TritonCommands._import(model, source=source)
         vllm_openai_server.start()
-        TritonCommands._profile(
-            model, service_kind="openai", endpoint_type="chat", url="localhost:9000"
-        )
+        TritonCommands._profile(model, endpoint_type="chat", url="localhost:9000")
 
     @pytest.mark.skipif(
         os.environ.get("CI_PIPELINE") == "GITHUB_ACTIONS",

--- a/tests/test_models/mock_llm/config.pbtxt
+++ b/tests/test_models/mock_llm/config.pbtxt
@@ -37,6 +37,18 @@ input [
     name: "max_tokens"
     data_type: TYPE_INT32
     dims: [ 1 ]
+  },
+  {
+    name: "exclude_input_in_output"
+    data_type: TYPE_BOOL
+    dims: [ 1 ]
+    optional: true
+  },
+  {
+    name: "stream"
+    data_type: TYPE_BOOL
+    dims: [ 1 ]
+    optional: true
   }
 ]
 output [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -73,15 +73,10 @@ class TritonCommands:
             args += ["-i", protocol]
         run(args)
 
-    def _profile(model, backend=None, service_kind=None, endpoint_type=None, url=None):
+    def _profile(model, backend=None, endpoint_type=None, url=None):
         args = ["profile", "-m", model]
         if backend:
             args += ["--backend", backend]
-
-        # Do not add the service_kind argument because it is deprecated in genai-perf
-        # for compatibility, convert service_kind to endpoint_type as needed.
-        if service_kind == "openai" and not endpoint_type:
-            endpoint_type = "chat"
 
         if endpoint_type:
             args += ["--endpoint-type", endpoint_type]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -83,6 +83,9 @@ class TritonCommands:
             args += ["--endpoint-type", endpoint_type]
         if url:
             args += ["--url", url]
+        # For mock models, use a real tokenizer since mock_llm doesn't exist on HuggingFace
+        if model == "mock_llm":
+            args += ["--tokenizer", "gpt2"]
         # NOTE: With default parameters, genai-perf may take upwards of 1m30s or 2m to run,
         # so limit the genai-perf run with --request-count to reduce time for testing purposes.
         args += ["--synthetic-input-tokens-mean", "100", "--", "--request-count", "10"]


### PR DESCRIPTION
This PR addresses the following CI test issues:
- L0_triton_cli_test_vllm -- base: [gpt2]
- L0_triton_cli_test_vllm -- base: [llama-2-7b-chat]
- L0_triton_cli_test_vllm -- base: [llama-3.1-8b-instruct]


The following changes have been introduced:
- Updated `geanai-perf` to the latest version and removed the deprecated option `--service-kind openai`
- Removed the deprecated vLLM parameter `"disable_log_requests"` and added the missing inputs to the `mock_llm` model
- Added the correct tokenizer names for each model